### PR TITLE
[Opt] allocate memory for all vectors in one time.

### DIFF
--- a/cpp/include/merlin/types.cuh
+++ b/cpp/include/merlin/types.cuh
@@ -53,6 +53,8 @@ template <class K, class V, class M, size_t DIM>
 struct Table {
   Bucket<K, V, M, DIM> *buckets;
   unsigned int *locks;            // Write lock for each bucket.
+  V **vectors;                    // Handles of the vectors on HBM or HMEM.
+  uint64_t num_of_memory_slices;  // Number of vectors memory slices.
   uint64_t capacity = 134217728;  // Initial capacity.
   uint64_t buckets_num;
   uint64_t buckets_size = 128;

--- a/cpp/tests/merlin_hashtable_test.cc.cu
+++ b/cpp/tests/merlin_hashtable_test.cc.cu
@@ -68,8 +68,8 @@ template <class T>
 using ValueType = ValueArrayBase<T>;
 
 int test_main() {
-  constexpr uint64_t INIT_SIZE = 32 * 1024 * 1024;
-  constexpr uint64_t KEY_NUM = 1 * 1024 * 1024;
+  constexpr uint64_t INIT_SIZE = 32 * 1024 * 1024ul;
+  constexpr uint64_t KEY_NUM = 1 * 1024 * 1024ul;
   constexpr uint64_t TEST_TIMES = 1;
   constexpr uint64_t DIM = 64;
 


### PR DESCRIPTION
- avoid the performance dropped significantly on large memory 
- After this PR, the time of upsert 1M KV with DIM=64 could reach :
    - 30ms into 128GB HMEM 
    - 37ms into 256 GB HMEM