### PR TITLE
Improve function signatures

### DIFF
--- a/include/merlin/types.cuh
+++ b/include/merlin/types.cuh
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <limits>
 #include <cuda/std/semaphore>
+#include <limits>
 
 namespace nv {
 namespace merlin {

--- a/include/merlin/types.cuh
+++ b/include/merlin/types.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <limits>
 #include <cuda/std/semaphore>
 
 namespace nv {
@@ -27,9 +27,9 @@ struct Meta {
   M val;
 };
 
-constexpr uint64_t EMPTY_KEY = 0xFFFFFFFFFFFFFFFF;
-constexpr uint64_t MAX_META = 0xFFFFFFFFFFFFFFFF;
-constexpr uint64_t EMPTY_META = 0lu;
+constexpr uint64_t EMPTY_KEY = UINT64_C(0xFFFFFFFFFFFFFFFF);
+constexpr uint64_t MAX_META = UINT64_C(0xFFFFFFFFFFFFFFFF);
+constexpr uint64_t EMPTY_META = UINT64_C(0);
 
 template <class K, class V, class M, size_t DIM>
 struct Bucket {

--- a/include/merlin/types.cuh
+++ b/include/merlin/types.cuh
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <stddef.h>
 #include <cuda/std/semaphore>
 #include <limits>
 

--- a/include/merlin/utils.cuh
+++ b/include/merlin/utils.cuh
@@ -185,9 +185,9 @@ __inline__ __device__ int64_t Murmur3HashDevice(int64_t const& key) {
 __inline__ __device__ uint32_t Murmur3HashDevice(uint32_t const& key) {
   uint32_t k = key;
   k ^= k >> 16;
-  k *= 0x85ebca6b;
+  k *= UINT32_C(0x85ebca6b);
   k ^= k >> 13;
-  k *= 0xc2b2ae35;
+  k *= UINT32_C(0xc2b2ae35);
   k ^= k >> 16;
 
   return k;
@@ -196,9 +196,9 @@ __inline__ __device__ uint32_t Murmur3HashDevice(uint32_t const& key) {
 __inline__ __device__ int32_t Murmur3HashDevice(int32_t const& key) {
   uint32_t k = uint32_t(key);
   k ^= k >> 16;
-  k *= 0x85ebca6b;
+  k *= UINT32_C(0x85ebca6b);
   k ^= k >> 13;
-  k *= 0xc2b2ae35;
+  k *= UINT32_C(0xc2b2ae35);
   k ^= k >> 16;
 
   return int32_t(k);


### PR DESCRIPTION
This fix contains multiple improvements:
1. Makes certain constant definitions compiler independent.
2. Add additional function signatures to avoid frequent casting in the body (this doesn't hurt now and will become much more useful once the resource pooling is merged).
3. Make code more readable by selecting the thrust parallel model only at a single location.