### PR TITLE
docs: Add semver to calver banner

### DIFF
--- a/docs/source/_static/css/banner.css
+++ b/docs/source/_static/css/banner.css
@@ -1,0 +1,34 @@
+.wy-nav-content {
+    margin: 0;
+    background: #fcfcfc;
+    padding-top: 40px;
+}
+
+.wy-side-nav-search {
+    display: block;
+    width: 300px;
+    padding: .809em;
+    padding-top: 0.809em;
+    margin-bottom: .809em;
+    z-index: 200;
+    background-color: #2980b9;
+    text-align: center;
+    color: #fcfcfc;
+    padding-top: 40px;
+}
+
+div.banner {
+    position: fixed;
+    top: 10px;
+    left: 20px;
+    margin: 0;
+    z-index: 1000;
+    width: 1050px;
+    text-align: center;
+}
+
+p.banner {
+  border-radius: 4px;
+  color: #004831;
+  background: #76b900;
+}

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,9 @@
+{% extends "!layout.html" %}
+{% block extrabody %}
+  <div class="banner">
+    <p class="banner">
+      Beginning in January 2023, versions for all NVIDIA Merlin projects
+      will change from semantic versioning like <code>4.0</code>
+      to calendar versioning like <code>23.01</code>.</p>
+  </div>
+{% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -126,7 +126,7 @@ html_sidebars = {"**": ["versions.html"]}
 html_baseurl = "https://nvidia-merlin.github.io/HierarchicalKV/master"
 
 html_static_path = [ '_static' ]
-html_css_files = [ "css/custom.css" ]
+html_css_files = [ "css/custom.css", "css/banner.css" ]
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
All Merlin projects are switching from semantic versioning, like `0.4.0`, to calendar versioning, like `23.01`. The change is planned for January 2023.
Add a banner to all pages to prepare our consumers for the change.