### PR TITLE
fix: reset workspace when insert_and_evict reuse mempool

### DIFF
--- a/include/merlin_hashtable.cuh
+++ b/include/merlin_hashtable.cuh
@@ -443,11 +443,14 @@ class HashTable {
     auto dn_evicted = reinterpret_cast<size_type*>(d_offsets + n_offsets);
     auto d_masks = reinterpret_cast<bool*>(dn_evicted + 1);
 
+    CUDA_CHECK(cudaMemsetAsync(d_offsets, 0, n_offsets * sizeof(int64_t)));
+    CUDA_CHECK(cudaMemsetAsync(dn_evicted, 0, sizeof(size_type), stream));
+    CUDA_CHECK(cudaMemsetAsync(d_masks, 0, n * sizeof(bool), stream));
+
     size_type block_size = options_.block_size;
     size_type grid_size = SAFE_GET_GRID_SIZE(n, block_size);
     CUDA_CHECK(cudaMemsetAsync(evicted_keys, static_cast<int>(EMPTY_KEY),
                                n * sizeof(K), stream));
-    CUDA_CHECK(cudaMemsetAsync(d_masks, 0, sizeof(bool) * n, stream));
 
     Selector::execute_kernel(load_factor, options_.block_size, stream, n,
                              c_table_index_, d_table_, keys, values, metas,


### PR DESCRIPTION
When reusing the workspace, the remained values in mempool can cause value error.