### PR TITLE
template the erase_if and export_batch_if API

### DIFF
--- a/tests/find_or_insert_ptr_test.cc.cu
+++ b/tests/find_or_insert_ptr_test.cc.cu
@@ -39,24 +39,22 @@ using Table = nv::merlin::HashTable<K, V, M>;
 using TableOptions = nv::merlin::HashTableOptions;
 
 template <class K, class M>
-__forceinline__ __device__ bool erase_if_pred(const K& key, M& meta,
-                                              const K& pattern,
-                                              const M& threshold) {
-  return ((key & 0x7f > pattern) && (meta > threshold));
-}
+struct EraseIfPredFunctor {
+  __forceinline__ __device__ bool operator()(const K& key, M& meta,
+                                             const K& pattern,
+                                             const M& threshold) {
+    return ((key & 0x7f > pattern) && (meta > threshold));
+  }
+};
 
 template <class K, class M>
-__device__ Table::Pred EraseIfPred = erase_if_pred<K, M>;
-
-template <class K, class M>
-__forceinline__ __device__ bool export_if_pred(const K& key, M& meta,
-                                               const K& pattern,
-                                               const M& threshold) {
-  return meta > threshold;
-}
-
-template <class K, class M>
-__device__ Table::Pred ExportIfPred = export_if_pred<K, M>;
+struct ExportIfPredFunctor {
+  __forceinline__ __device__ bool operator()(const K& key, M& meta,
+                                             const K& pattern,
+                                             const M& threshold) {
+    return meta > threshold;
+  }
+};
 
 void test_basic(size_t max_hbm_for_vectors) {
   constexpr uint64_t INIT_CAPACITY = 64 * 1024 * 1024UL;
@@ -546,8 +544,8 @@ void test_erase_if_pred(size_t max_hbm_for_vectors) {
 
     K pattern = 100;
     M threshold = 0;
-    size_t erase_num =
-        table->erase_if(EraseIfPred<K, M>, pattern, threshold, stream);
+    size_t erase_num = table->template erase_if<EraseIfPredFunctor>(
+        pattern, threshold, stream);
     total_size = table->size(stream);
     CUDA_CHECK(cudaStreamSynchronize(stream));
     ASSERT_EQ((erase_num + total_size), BUCKET_MAX_SIZE);
@@ -1212,9 +1210,9 @@ void test_export_batch_if(size_t max_hbm_for_vectors) {
     K pattern = 100;
     M threshold = h_metas[size_t(KEY_NUM / 2)];
 
-    table->export_batch_if(ExportIfPred<K, M>, pattern, threshold,
-                           table->capacity(), 0, d_dump_counter, d_keys,
-                           d_vectors, d_metas, stream);
+    table->template export_batch_if<ExportIfPredFunctor>(
+        pattern, threshold, table->capacity(), 0, d_dump_counter, d_keys,
+        d_vectors, d_metas, stream);
 
     CUDA_CHECK(cudaStreamSynchronize(stream));
     CUDA_CHECK(cudaMemcpy(&h_dump_counter, d_dump_counter, sizeof(size_t),

--- a/tests/merlin_hashtable_test.cc.cu
+++ b/tests/merlin_hashtable_test.cc.cu
@@ -36,24 +36,22 @@ using Table = nv::merlin::HashTable<K, V, M>;
 using TableOptions = nv::merlin::HashTableOptions;
 
 template <class K, class M>
-__forceinline__ __device__ bool erase_if_pred(const K& key, M& meta,
-                                              const K& pattern,
-                                              const M& threshold) {
-  return ((key & 0x7f > pattern) && (meta > threshold));
-}
+struct EraseIfPredFunctor {
+  __forceinline__ __device__ bool operator()(const K& key, M& meta,
+                                             const K& pattern,
+                                             const M& threshold) {
+    return ((key & 0x7f > pattern) && (meta > threshold));
+  }
+};
 
 template <class K, class M>
-__device__ Table::Pred EraseIfPred = erase_if_pred<K, M>;
-
-template <class K, class M>
-__forceinline__ __device__ bool export_if_pred(const K& key, M& meta,
-                                               const K& pattern,
-                                               const M& threshold) {
-  return meta > threshold;
-}
-
-template <class K, class M>
-__device__ Table::Pred ExportIfPred = export_if_pred<K, M>;
+struct ExportIfPredFunctor {
+  __forceinline__ __device__ bool operator()(const K& key, M& meta,
+                                             const K& pattern,
+                                             const M& threshold) {
+    return meta > threshold;
+  }
+};
 
 void test_basic(size_t max_hbm_for_vectors) {
   constexpr uint64_t BUCKET_MAX_SIZE = 128;
@@ -433,8 +431,8 @@ void test_erase_if_pred(size_t max_hbm_for_vectors) {
 
     K pattern = 100;
     M threshold = 0;
-    size_t erase_num =
-        table->erase_if(EraseIfPred<K, M>, pattern, threshold, stream);
+    size_t erase_num = table->template erase_if<EraseIfPredFunctor>(
+        pattern, threshold, stream);
     total_size = table->size(stream);
     CUDA_CHECK(cudaStreamSynchronize(stream));
     ASSERT_EQ((erase_num + total_size), BUCKET_MAX_SIZE);
@@ -971,9 +969,9 @@ void test_export_batch_if(size_t max_hbm_for_vectors) {
     K pattern = 100;
     M threshold = h_metas[size_t(KEY_NUM / 2)];
 
-    table->export_batch_if(ExportIfPred<K, M>, pattern, threshold,
-                           table->capacity(), 0, d_dump_counter, d_keys,
-                           d_vectors, d_metas, stream);
+    table->template export_batch_if<ExportIfPredFunctor>(
+        pattern, threshold, table->capacity(), 0, d_dump_counter, d_keys,
+        d_vectors, d_metas, stream);
 
     CUDA_CHECK(cudaStreamSynchronize(stream));
     CUDA_CHECK(cudaMemcpy(&h_dump_counter, d_dump_counter, sizeof(size_t),


### PR DESCRIPTION
APIs like `erase_if` and `export_batch_if` use function pointer to enable multiple policies to match the keys in table. But It can easily lead to issues like memory access error, misaligned address(#125), performance downgrade.

This PR change the APIs with approach of Templating which avoid issues above.