### PR TITLE
[Feat]: find API with missing parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,10 @@ add_executable(merlin_hashtable_benchmark benchmark/merlin_hashtable_benchmark.c
 target_compile_features(merlin_hashtable_benchmark PUBLIC cxx_std_14)
 set_target_properties(merlin_hashtable_benchmark PROPERTIES  CUDA_ARCHITECTURES OFF)
 
+add_executable(find_with_missed_keys_benchmark benchmark/find_with_missed_keys_benchmark.cc.cu)
+target_compile_features(find_with_missed_keys_benchmark PUBLIC cxx_std_14)
+set_target_properties(find_with_missed_keys_benchmark PROPERTIES  CUDA_ARCHITECTURES OFF)
+
 add_executable(merlin_hashtable_test tests/merlin_hashtable_test.cc.cu)
 target_compile_features(merlin_hashtable_test PUBLIC cxx_std_14)
 set_target_properties(merlin_hashtable_test PROPERTIES  CUDA_ARCHITECTURES OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,3 +150,8 @@ add_executable(assign_values_test tests/assign_values_test.cc.cu)
 target_compile_features(assign_values_test PUBLIC cxx_std_14)
 set_target_properties(assign_values_test PROPERTIES  CUDA_ARCHITECTURES OFF)
 TARGET_LINK_LIBRARIES(assign_values_test gtest_main)
+
+add_executable(find_with_missed_keys_test tests/find_with_missed_keys_test.cc.cu)
+target_compile_features(find_with_missed_keys_test PUBLIC cxx_std_14)
+set_target_properties(find_with_missed_keys_test PROPERTIES  CUDA_ARCHITECTURES OFF)
+TARGET_LINK_LIBRARIES(find_with_missed_keys_test gtest_main)

--- a/benchmark/find_with_missed_keys_benchmark.cc.cu
+++ b/benchmark/find_with_missed_keys_benchmark.cc.cu
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <assert.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <random>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "benchmark_util.cuh"
+#include "merlin_hashtable.cuh"
+
+using K = uint64_t;
+using V = float;
+using S = uint64_t;
+using EvictStrategy = nv::merlin::EvictStrategy;
+using TableOptions = nv::merlin::HashTableOptions;
+using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+void print_tile() {
+  std::cout << std::endl
+            << "|    \u03BB "
+            << "| capacity "
+            << "| max_hbm_for_vectors "
+            << "| max_bucket_size "
+            << "| dim "
+            << "| missed_ratio "
+            << "| througput(BillionKV/secs) ";
+  std::cout << "|\n";
+
+  //<< "| load_factor "
+  std::cout << "|------"
+            //<< "| capacity "
+            << "|----------"
+            //<< "| max_hbm_for_vectors "
+            << "|---------------------"
+            //<< "| max_bucket_size "
+            << "|-----------------"
+            //<< "| dim "
+            << "|-----"
+            //<< "| missed_ratio "
+            << "|--------------"
+            //<< "| througput(BillionKV/secs) "
+            << "|---------------------------";
+  std::cout << "|\n";
+}
+
+template <typename T>
+void print_w(const T& t, size_t width) {
+  std::cout << "|" << std::setw(width) << t;
+}
+
+void print_result(double load_factor, size_t capacity,
+                  size_t max_hbm_for_vectors, size_t max_bucket_size,
+                  size_t dim, double missed_ratio, float througput) {
+  print_w(load_factor, 6);
+  print_w(capacity, 10);
+  print_w(max_hbm_for_vectors, 21);
+  print_w(max_bucket_size, 17);
+  print_w(dim, 5);
+  print_w(missed_ratio, 14);
+  print_w(througput, 27);
+  std::cout << "|\n";
+}
+
+void test_find(size_t capacity, size_t dim, size_t max_hbm_for_vectors,
+               double load_factor, size_t max_bucket_size,
+               double missed_ratio) {
+  MERLIN_CHECK(load_factor >= 0.0 && load_factor <= 1.0,
+               "Invalid `load_factor`");
+  K* h_keys;
+  S* h_scores;
+  V* h_vectors;
+
+  TableOptions options;
+  options.init_capacity = capacity;
+  options.max_capacity = capacity;
+  options.dim = dim;
+
+  options.max_hbm_for_vectors = nv::merlin::MB(max_hbm_for_vectors);
+  options.max_bucket_size = max_bucket_size;
+
+  size_t key_num = capacity;
+  CUDA_CHECK(cudaMallocHost(&h_keys, key_num * sizeof(K)));
+  CUDA_CHECK(cudaMallocHost(&h_scores, key_num * sizeof(S)));
+  CUDA_CHECK(cudaMallocHost(&h_vectors, key_num * options.dim * sizeof(V)));
+
+  K* d_keys;
+  S* d_scores;
+  V* d_vectors;
+  K* d_missed_keys;
+  int* d_missed_indices;
+  int* d_missed_size;
+
+  CUDA_CHECK(cudaMalloc(&d_keys, key_num * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_scores, key_num * sizeof(S)));
+  CUDA_CHECK(cudaMalloc(&d_vectors, key_num * sizeof(V) * options.dim));
+  CUDA_CHECK(cudaMalloc(&d_missed_keys, key_num * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_missed_indices, key_num * sizeof(int)));
+  CUDA_CHECK(cudaMalloc(&d_missed_size, sizeof(int)));
+
+  cudaStream_t stream;
+  CUDA_CHECK(cudaStreamCreate(&stream));
+  // insert key-value
+  size_t insert_num = (double)key_num * load_factor;
+  benchmark::create_continuous_keys<K, S>(h_keys, h_scores, insert_num,
+                                          0 /*start*/);
+  benchmark::init_value_using_key<K, V>(h_keys, h_vectors, insert_num,
+                                        options.dim);
+  CUDA_CHECK(cudaMemcpy(d_keys, h_keys, insert_num * sizeof(K),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_scores, h_scores, insert_num * sizeof(S),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_vectors, h_vectors,
+                        insert_num * sizeof(V) * options.dim,
+                        cudaMemcpyHostToDevice));
+  Table table;
+  table.init(options);
+  table.insert_or_assign(insert_num, d_keys, d_vectors, d_scores, stream);
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+
+  // find key-value
+  size_t find_num = (double)insert_num * (1.0 - missed_ratio);
+  benchmark::create_continuous_keys<K, S>(h_keys, nullptr, find_num,
+                                          0 /*start*/);
+  benchmark::create_continuous_keys<K, S>(
+      h_keys + find_num, nullptr, insert_num - find_num, insert_num /*start*/);
+  CUDA_CHECK(cudaMemcpy(d_keys, h_keys, insert_num * sizeof(K),
+                        cudaMemcpyHostToDevice));
+
+  auto timer = benchmark::Timer<double>();
+  timer.start();
+  table.find(insert_num, d_keys, d_vectors, d_missed_keys, d_missed_indices,
+             d_missed_size, d_scores, stream);
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  timer.end();
+
+  CUDA_CHECK(cudaFreeHost(h_keys));
+  CUDA_CHECK(cudaFreeHost(h_scores));
+  CUDA_CHECK(cudaFreeHost(h_vectors));
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_scores));
+  CUDA_CHECK(cudaFree(d_vectors));
+  CUDA_CHECK(cudaFree(d_missed_keys));
+  CUDA_CHECK(cudaFree(d_missed_indices));
+  CUDA_CHECK(cudaFree(d_missed_size));
+
+  CudaCheckError();
+  float througput = insert_num / timer.getResult() / (1024 * 1024 * 1024.0f);
+  print_result(load_factor, capacity, max_hbm_for_vectors, max_bucket_size, dim,
+               missed_ratio, througput);
+}
+
+void test_main(double load_factor, double missed_ratio) {
+  constexpr size_t CAPACITY = 100000000UL;
+  print_tile();
+  // pure HBM
+  test_find(CAPACITY, 8, 8 * 1024UL, load_factor, 256, missed_ratio);
+  test_find(CAPACITY, 8, 8 * 1024UL, load_factor, 128, missed_ratio);
+  // hybrid
+  test_find(CAPACITY, 8, 1 * 1024UL, load_factor, 256, missed_ratio);
+  test_find(CAPACITY, 8, 1 * 1024UL, load_factor, 128, missed_ratio);
+  // pure HMEM
+  test_find(CAPACITY, 8, 0, load_factor, 256, missed_ratio);
+  test_find(CAPACITY, 8, 0, load_factor, 128, missed_ratio);
+}
+
+int main() {
+  test_main(0.2, 0);
+  test_main(0.2, 0.5);
+  test_main(0.2, 1.0);
+  test_main(0.5, 0);
+  test_main(0.5, 0.5);
+  test_main(0.5, 1.0);
+  test_main(1.0, 0);
+  test_main(1.0, 0.5);
+  test_main(1.0, 1.0);
+  return 0;
+}

--- a/include/merlin/core_kernels.cuh
+++ b/include/merlin/core_kernels.cuh
@@ -588,7 +588,7 @@ __global__ void read_kernel(const V* const* __restrict src, V* __restrict dst,
  *  `N`: Number of vectors needed to be read.
  */
 template <class K, class V, class S>
-__global__ void read_kernel(const V** __restrict src, V* __restrict dst,
+__global__ void read_kernel(const V* const* __restrict src, V* __restrict dst,
                             const int* __restrict dst_offset, const size_t dim,
                             const size_t N) {
   size_t tid = (blockIdx.x * blockDim.x) + threadIdx.x;
@@ -599,10 +599,11 @@ __global__ void read_kernel(const V** __restrict src, V* __restrict dst,
         dst_offset != nullptr ? dst_offset[vec_index] : vec_index;
     int dim_index = t % dim;
     if (src[vec_index] != nullptr) {
-      dst[real_dst_offset * dim + dim_index] = src[vec_index * dim + dim_index];
+      dst[real_dst_offset * dim + dim_index] = src[vec_index][dim_index];
     }
   }
 }
+
 /* Clear all key-value in the table. */
 template <class K, class V, class S>
 __global__ void clear_kernel(Table<K, V, S>* __restrict table,

--- a/tests/find_with_missed_keys_test.cc.cu
+++ b/tests/find_with_missed_keys_test.cc.cu
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <vector>
+#include "merlin_hashtable.cuh"
+#include "test_util.cuh"
+
+constexpr size_t DIM = 16;
+using K = uint64_t;
+using V = float;
+using S = uint64_t;
+using EvictStrategy = nv::merlin::EvictStrategy;
+using TableOptions = nv::merlin::HashTableOptions;
+
+void test_find(size_t max_hbm_for_vectors, size_t max_bucket_size,
+               double load_factor, bool pipeline_lookup) {
+  MERLIN_CHECK(load_factor >= 0.0 && load_factor <= 1.0,
+               "Invalid `load_factor`");
+
+  constexpr uint64_t INIT_CAPACITY = 1024 * 1024UL;
+  constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
+  constexpr uint64_t KEY_NUM = INIT_CAPACITY;
+  constexpr uint64_t TEST_TIMES = 1;
+
+  K* h_keys;
+  S* h_scores;
+  V* h_vectors;
+  K* h_missed_keys;
+  int* h_missed_indices;
+
+  TableOptions options;
+
+  options.init_capacity = INIT_CAPACITY;
+  options.max_capacity = MAX_CAPACITY;
+  options.dim = DIM;
+  options.max_hbm_for_vectors = nv::merlin::MB(max_hbm_for_vectors);
+  if (pipeline_lookup) {
+    options.max_bucket_size = 128;
+  } else {
+    options.max_bucket_size = 256;
+  }
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+  CUDA_CHECK(cudaMallocHost(&h_keys, KEY_NUM * sizeof(K)));
+  CUDA_CHECK(cudaMallocHost(&h_scores, KEY_NUM * sizeof(S)));
+  CUDA_CHECK(cudaMallocHost(&h_vectors, KEY_NUM * sizeof(V) * options.dim));
+  CUDA_CHECK(cudaMallocHost(&h_missed_keys, KEY_NUM * sizeof(K)));
+  CUDA_CHECK(cudaMallocHost(&h_missed_indices, KEY_NUM * sizeof(int)));
+
+  K* d_keys;
+  S* d_scores;
+  V* d_vectors;
+  K* d_missed_keys;
+  int* d_missed_indices;
+  int* d_missed_size;
+
+  CUDA_CHECK(cudaMalloc(&d_keys, KEY_NUM * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_scores, KEY_NUM * sizeof(S)));
+  CUDA_CHECK(cudaMalloc(&d_vectors, KEY_NUM * sizeof(V) * options.dim));
+  CUDA_CHECK(cudaMalloc(&d_missed_keys, KEY_NUM * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_missed_indices, KEY_NUM * sizeof(int)));
+  CUDA_CHECK(cudaMalloc(&d_missed_size, sizeof(int)));
+
+  cudaStream_t stream;
+  CUDA_CHECK(cudaStreamCreate(&stream));
+
+  int missed_size;
+  for (int i = 0; i < TEST_TIMES; ++i) {
+    CUDA_CHECK(cudaMemset(h_vectors, 0, KEY_NUM * sizeof(V) * options.dim));
+    test_util::create_random_keys<K, S, V, DIM>(h_keys, h_scores, h_vectors,
+                                                KEY_NUM);
+    CUDA_CHECK(cudaMemcpy(d_keys, h_keys, KEY_NUM * sizeof(K),
+                          cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_scores, h_scores, KEY_NUM * sizeof(S),
+                          cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_vectors, h_vectors,
+                          KEY_NUM * sizeof(V) * options.dim,
+                          cudaMemcpyHostToDevice));
+
+    Table table;
+    table.init(options);
+    size_t size = table.size(stream);
+    ASSERT_EQ(size, 0);
+
+    size_t insert_num = (double)KEY_NUM * load_factor;
+    table.insert_or_assign(insert_num, d_keys, d_vectors, d_scores, stream);
+    table.find(KEY_NUM, d_keys, d_vectors, d_missed_keys, d_missed_indices,
+               d_missed_size, d_scores, stream);
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+
+    CUDA_CHECK(cudaMemcpy(&missed_size, d_missed_size, sizeof(int),
+                          cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_missed_keys, d_missed_keys, missed_size * sizeof(K),
+                          cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_missed_indices, d_missed_indices,
+                          missed_size * sizeof(int), cudaMemcpyDeviceToHost));
+
+    if (insert_num == 0) {
+      ASSERT_EQ(missed_size, KEY_NUM);
+    } else {
+      CUDA_CHECK(cudaMemcpy(h_vectors, d_vectors,
+                            KEY_NUM * sizeof(V) * options.dim,
+                            cudaMemcpyDeviceToHost));
+
+      ASSERT_TRUE(missed_size > 0 && missed_size < KEY_NUM);
+      std::vector<bool> founds(KEY_NUM, true);
+      // Check missed
+      for (int j = 0; j < missed_size; ++j) {
+        int idx = h_missed_indices[i];
+        ASSERT_TRUE(idx >= 0 && idx < KEY_NUM);
+        ASSERT_EQ(h_keys[idx], h_missed_keys[i]);
+        founds[idx] = false;
+      }
+      // Check hitted
+      for (uint64_t j = 0; j < KEY_NUM; ++j) {
+        if (founds[j]) {
+          for (int k = 0; k < options.dim; ++k) {
+            ASSERT_EQ(h_vectors[j * options.dim + k],
+                      static_cast<float>(h_keys[j] * 0.00001));
+          }
+        }
+      }
+    }
+  }
+
+  CUDA_CHECK(cudaFreeHost(h_keys));
+  CUDA_CHECK(cudaFreeHost(h_scores));
+  CUDA_CHECK(cudaFreeHost(h_vectors));
+  CUDA_CHECK(cudaFreeHost(h_missed_keys));
+  CUDA_CHECK(cudaFreeHost(h_missed_indices));
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_scores));
+  CUDA_CHECK(cudaFree(d_vectors));
+  CUDA_CHECK(cudaFree(d_missed_keys));
+  CUDA_CHECK(cudaFree(d_missed_indices));
+  CUDA_CHECK(cudaFree(d_missed_size));
+
+  CudaCheckError();
+}
+
+TEST(FindTest, test_find_when_empty) {
+  // pure HMEM
+  test_find(0, 128, 0.0, true);
+  test_find(0, 256, 0.0, false);
+  // hybrid
+  test_find(32, 128, 0.0, true);
+  test_find(32, 256, 0.0, false);
+  // pure HBM
+  test_find(1024, 128, 0.0, true);
+  test_find(1024, 256, 0.0, false);
+}
+
+TEST(FindTest, test_find_when_full) {
+  // pure HMEM
+  test_find(0, 128, 1.0, true);
+  test_find(0, 256, 1.0, false);
+  // hybrid
+  test_find(32, 128, 1.0, true);
+  test_find(32, 256, 1.0, false);
+  // pure HBM
+  test_find(1024, 128, 1.0, true);
+  test_find(1024, 256, 1.0, false);
+}
+
+TEST(FindTest, test_find_load_factor) {
+  // pure HMEM
+  test_find(0, 128, 0.2, true);
+  test_find(0, 256, 0.2, false);
+  // hybrid
+  test_find(32, 128, 0.2, true);
+  test_find(32, 256, 0.2, false);
+  // pure HBM
+  test_find(1024, 128, 0.2, true);
+  test_find(1024, 256, 0.2, false);
+
+  // pure HMEM
+  test_find(0, 128, 0.5, true);
+  test_find(0, 256, 0.5, false);
+  // hybrid
+  test_find(32, 128, 0.5, true);
+  test_find(32, 256, 0.5, false);
+  // pure HBM
+  test_find(1024, 128, 0.5, true);
+  test_find(1024, 256, 0.5, false);
+
+  // pure HMEM
+  test_find(0, 128, 0.75, true);
+  test_find(0, 256, 0.75, false);
+  // hybrid
+  test_find(32, 128, 0.75, true);
+  test_find(32, 256, 0.75, false);
+  // pure HBM
+  test_find(1024, 128, 0.75, true);
+  test_find(1024, 256, 0.75, false);
+}


### PR DESCRIPTION
In our inference service, we found that the find API will have better performance by directly writing the missed keys when the hit rate is high, which it usually is.