### PR TITLE
[fix] Removed the thread_local attribute of global_epoch

### DIFF
--- a/benchmark/find_with_missed_keys_benchmark.cc.cu
+++ b/benchmark/find_with_missed_keys_benchmark.cc.cu
@@ -15,7 +15,6 @@
  */
 
 #include <assert.h>
-
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -29,7 +28,6 @@
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
-
 #include "benchmark_util.cuh"
 #include "merlin_hashtable.cuh"
 

--- a/benchmark/merlin_hashtable_benchmark.cc.cu
+++ b/benchmark/merlin_hashtable_benchmark.cc.cu
@@ -124,7 +124,7 @@ float test_one_api(std::shared_ptr<Table>& table, const API_Select api,
   S threshold = benchmark::host_nano<S>();
   int global_epoch = 0;
   for (; global_epoch < loop_num_init; global_epoch++) {
-    EvictStrategy::set_global_epoch(global_epoch);
+    table->set_global_epoch(global_epoch);
     uint64_t key_num_cur_insert =
         global_epoch == loop_num_init - 1 ? key_num_remain : key_num_per_op;
     create_continuous_keys<K, S>(h_keys, h_scores, key_num_cur_insert, start);
@@ -165,7 +165,7 @@ float test_one_api(std::shared_ptr<Table>& table, const API_Select api,
   // For trigger the kernel selection in advance.
   int key_num_per_op_warmup = 1;
   for (int i = 0; i < 9; i++, global_epoch++) {
-    EvictStrategy::set_global_epoch(global_epoch);
+    table->set_global_epoch(global_epoch);
     switch (api) {
       case API_Select::find: {
         table->find(key_num_per_op_warmup, d_keys, d_vectors, d_found, d_scores,
@@ -271,7 +271,7 @@ float test_one_api(std::shared_ptr<Table>& table, const API_Select api,
                         cudaMemcpyHostToDevice));
   auto timer = benchmark::Timer<double>();
   global_epoch++;
-  EvictStrategy::set_global_epoch(global_epoch);
+  table->set_global_epoch(global_epoch);
   switch (api) {
     case API_Select::find: {
       timer.start();

--- a/include/merlin/types.cuh
+++ b/include/merlin/types.cuh
@@ -275,12 +275,5 @@ struct EvictStrategyInternal {
   constexpr static int kCustomized = 4;  ///< Customized mode.
 };
 
-union EvictStrategyParamUnion {  ///< Parameter for specialized strategy.
-  uint64_t global_epoch;
-};
-
-thread_local static EvictStrategyParamUnion EvictStrategyParam = {
-    static_cast<uint64_t>(IGNORED_GLOBAL_EPOCH)};
-
 }  // namespace merlin
 }  // namespace nv

--- a/tests/accum_or_assign_test.cc.cu
+++ b/tests/accum_or_assign_test.cc.cu
@@ -1247,7 +1247,7 @@ void test_evict_strategy_lfu_basic(size_t max_hbm_for_vectors) {
           cudaMemcpy(d_accum_or_assigns_temp, h_accum_or_assigns_base.data(),
                      BASE_KEY_NUM * sizeof(bool), cudaMemcpyHostToDevice));
 
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->accum_or_assign(BASE_KEY_NUM, d_keys_temp, d_vectors_temp,
                              d_accum_or_assigns_temp, d_scores_temp, stream);
 
@@ -1296,7 +1296,7 @@ void test_evict_strategy_lfu_basic(size_t max_hbm_for_vectors) {
           cudaMemcpy(d_accum_or_assigns_temp, h_accum_or_assigns_test.data(),
                      TEST_KEY_NUM * sizeof(bool), cudaMemcpyHostToDevice));
 
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->accum_or_assign(TEST_KEY_NUM, d_keys_temp, d_vectors_temp,
                              d_accum_or_assigns_temp, d_scores_temp, stream);
 
@@ -1464,7 +1464,7 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors) {
                      BASE_KEY_NUM * sizeof(bool), cudaMemcpyHostToDevice));
       S start_ts =
           (test_util::host_nano<S>(stream) >> RSHIFT_ON_NANO) & 0xFFFFFFFF;
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->accum_or_assign(BASE_KEY_NUM, d_keys_temp, d_vectors_temp,
                              d_accum_or_assigns_temp, nullptr, stream);
       CUDA_CHECK(cudaStreamSynchronize(stream));
@@ -1515,7 +1515,7 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors) {
                      TEST_KEY_NUM * sizeof(bool), cudaMemcpyHostToDevice));
       S start_ts =
           (test_util::host_nano<S>(stream) >> RSHIFT_ON_NANO) & 0xFFFFFFFF;
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->accum_or_assign(TEST_KEY_NUM, d_keys_temp, d_vectors_temp,
                              d_accum_or_assigns_temp, nullptr, stream);
       CUDA_CHECK(cudaStreamSynchronize(stream));
@@ -1704,7 +1704,7 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors) {
           cudaMemcpy(d_accum_or_assigns_temp, h_accum_or_assigns_base.data(),
                      BASE_KEY_NUM * sizeof(bool), cudaMemcpyHostToDevice));
 
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->accum_or_assign(BASE_KEY_NUM, d_keys_temp, d_vectors_temp,
                              d_accum_or_assigns_temp, d_scores_temp, stream);
 
@@ -1761,7 +1761,7 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors) {
           cudaMemcpy(d_accum_or_assigns_temp, h_accum_or_assigns_test.data(),
                      TEST_KEY_NUM * sizeof(bool), cudaMemcpyHostToDevice));
 
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->accum_or_assign(TEST_KEY_NUM, d_keys_temp, d_vectors_temp,
                              d_accum_or_assigns_temp, d_scores_temp, stream);
 

--- a/tests/assign_score_test.cc.cu
+++ b/tests/assign_score_test.cc.cu
@@ -473,7 +473,7 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors) {
                             cudaMemcpyHostToDevice));
       S start_ts =
           (test_util::host_nano<S>(stream) >> RSHIFT_ON_NANO) & 0xFFFFFFFF;
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->find_or_insert(BASE_KEY_NUM, d_keys_temp, d_vectors_temp, nullptr,
                             stream);
       CUDA_CHECK(cudaStreamSynchronize(stream));
@@ -521,7 +521,7 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors) {
                             cudaMemcpyHostToDevice));
       S start_ts =
           (test_util::host_nano<S>(stream) >> RSHIFT_ON_NANO) & 0xFFFFFFFF;
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->assign(TEST_KEY_NUM, d_keys_temp, nullptr, stream);
       table->find_or_insert(TEST_KEY_NUM, d_keys_temp, d_vectors_temp, nullptr,
                             stream);
@@ -670,7 +670,7 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors) {
       CUDA_CHECK(cudaMemcpy(d_vectors_temp, h_vectors_base.data(),
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyHostToDevice));
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->find_or_insert(BASE_KEY_NUM, d_keys_temp, d_vectors_temp,
                             d_scores_temp, stream);
       CUDA_CHECK(cudaStreamSynchronize(stream));
@@ -717,7 +717,7 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors) {
       CUDA_CHECK(cudaMemcpy(d_vectors_temp, h_vectors_test.data(),
                             TEST_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyHostToDevice));
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->assign(TEST_KEY_NUM, d_keys_temp, d_scores_temp, stream);
       table->find_or_insert(TEST_KEY_NUM, d_keys_temp, d_vectors_temp,
                             d_scores_temp, stream);
@@ -1250,7 +1250,7 @@ void CheckAssignOnEpochLfu(Table* table,
     scores_map_before_insert[h_tmp_keys[i]] = h_tmp_scores[i];
   }
 
-  EvictStrategy::set_global_epoch(global_epoch);
+  table->set_global_epoch(global_epoch);
   table->assign(len, keys, scores, stream);
   CUDA_CHECK(cudaStreamSynchronize(stream));
 

--- a/tests/assign_values_test.cc.cu
+++ b/tests/assign_values_test.cc.cu
@@ -295,7 +295,7 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors) {
       CUDA_CHECK(cudaMemcpy(d_vectors_temp, h_vectors_base.data(),
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyHostToDevice));
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->find_or_insert(BASE_KEY_NUM, d_keys_temp, d_vectors_temp,
                             d_scores_temp, stream);
       CUDA_CHECK(cudaStreamSynchronize(stream));
@@ -547,7 +547,7 @@ void CheckAssignOnEpochLfu(Table* table,
   values_map_after_insert.clear();
   scores_map_after_insert.clear();
 
-  EvictStrategy::set_global_epoch(global_epoch);
+  table->set_global_epoch(global_epoch);
   auto start = std::chrono::steady_clock::now();
   size_t filtered_len = table->insert_and_evict(
       len, keys, values,

--- a/tests/find_or_insert_ptr_test.cc.cu
+++ b/tests/find_or_insert_ptr_test.cc.cu
@@ -1963,7 +1963,7 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors) {
                              BASE_KEY_NUM, stream);
         start_ts =
             (test_util::host_nano<S>(stream) >> RSHIFT_ON_NANO) & 0xFFFFFFFF;
-        EvictStrategy::set_global_epoch(global_epoch);
+        table->set_global_epoch(global_epoch);
         table->find_or_insert(BASE_KEY_NUM, d_keys_temp, d_vectors_ptr, d_found,
                               nullptr, stream);
         test_util::read_or_write_ptr(d_vectors_ptr, d_vectors_temp, d_found,
@@ -2018,7 +2018,7 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors) {
                             cudaMemcpyHostToDevice));
       start_ts =
           (test_util::host_nano<S>(stream) >> RSHIFT_ON_NANO) & 0xFFFFFFFF;
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->assign(TEST_KEY_NUM, d_keys_temp, d_vectors_temp, nullptr, stream);
       {
         V** d_vectors_ptr = nullptr;
@@ -2189,7 +2189,7 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors) {
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, BASE_KEY_NUM * sizeof(V*)));
         test_util::array2ptr(d_vectors_ptr, d_vectors_temp, options.dim,
                              BASE_KEY_NUM, stream);
-        EvictStrategy::set_global_epoch(global_epoch);
+        table->set_global_epoch(global_epoch);
         table->find_or_insert(BASE_KEY_NUM, d_keys_temp, d_vectors_ptr, d_found,
                               d_scores_temp, stream);
         test_util::read_or_write_ptr(d_vectors_ptr, d_vectors_temp, d_found,
@@ -2243,7 +2243,7 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors) {
       CUDA_CHECK(cudaMemcpy(d_vectors_temp, h_vectors_test.data(),
                             TEST_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyHostToDevice));
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->assign(TEST_KEY_NUM, d_keys_temp, d_vectors_temp, d_scores_temp,
                     stream);
       {

--- a/tests/find_or_insert_test.cc.cu
+++ b/tests/find_or_insert_test.cc.cu
@@ -1736,7 +1736,7 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors) {
                             cudaMemcpyHostToDevice));
       S start_ts =
           (test_util::host_nano<S>(stream) >> RSHIFT_ON_NANO) & 0xFFFFFFFF;
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->find_or_insert(BASE_KEY_NUM, d_keys_temp, d_vectors_temp, nullptr,
                             stream);
       CUDA_CHECK(cudaStreamSynchronize(stream));
@@ -1784,7 +1784,7 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors) {
                             cudaMemcpyHostToDevice));
       S start_ts =
           (test_util::host_nano<S>(stream) >> RSHIFT_ON_NANO) & 0xFFFFFFFF;
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->assign(TEST_KEY_NUM, d_keys_temp, d_vectors_temp, nullptr, stream);
       table->find_or_insert(TEST_KEY_NUM, d_keys_temp, d_vectors_temp, nullptr,
                             stream);
@@ -1933,7 +1933,7 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors) {
       CUDA_CHECK(cudaMemcpy(d_vectors_temp, h_vectors_base.data(),
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyHostToDevice));
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->find_or_insert(BASE_KEY_NUM, d_keys_temp, d_vectors_temp,
                             d_scores_temp, stream);
       CUDA_CHECK(cudaStreamSynchronize(stream));
@@ -1980,7 +1980,7 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors) {
       CUDA_CHECK(cudaMemcpy(d_vectors_temp, h_vectors_test.data(),
                             TEST_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyHostToDevice));
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->assign(TEST_KEY_NUM, d_keys_temp, d_vectors_temp, d_scores_temp,
                     stream);
       table->find_or_insert(TEST_KEY_NUM, d_keys_temp, d_vectors_temp,
@@ -2516,7 +2516,7 @@ void CheckAssignOnEpochLfu(Table* table,
     scores_map_before_insert[h_tmp_keys[i]] = h_tmp_scores[i];
   }
 
-  EvictStrategy::set_global_epoch(global_epoch);
+  table->set_global_epoch(global_epoch);
   table->assign(len, keys, values, scores, stream);
   CUDA_CHECK(cudaStreamSynchronize(stream));
 

--- a/tests/insert_and_evict_test.cc.cu
+++ b/tests/insert_and_evict_test.cc.cu
@@ -453,7 +453,7 @@ void CheckInsertAndEvictOnLfu(Table* table,
   }
 
   auto start = std::chrono::steady_clock::now();
-  EvictStrategy::set_global_epoch(global_epoch);
+  table->set_global_epoch(global_epoch);
   size_t filtered_len = table->insert_and_evict(
       len, keys, values,
       (Table::evict_strategy == EvictStrategy::kLru ||
@@ -724,7 +724,7 @@ void CheckInsertAndEvictOnEpochLru(Table* table,
   S nano_before_insert = test_util::host_nano<S>();
 
   auto start = std::chrono::steady_clock::now();
-  EvictStrategy::set_global_epoch(global_epoch);
+  table->set_global_epoch(global_epoch);
   size_t filtered_len = table->insert_and_evict(
       len, keys, values,
       (Table::evict_strategy == EvictStrategy::kLru ||
@@ -995,7 +995,7 @@ void CheckInsertAndEvictOnEpochLfu(
   }
 
   auto start = std::chrono::steady_clock::now();
-  EvictStrategy::set_global_epoch(global_epoch);
+  table->set_global_epoch(global_epoch);
   size_t filtered_len = table->insert_and_evict(
       len, keys, values,
       (Table::evict_strategy == EvictStrategy::kLru ||

--- a/tests/merlin_hashtable_test.cc.cu
+++ b/tests/merlin_hashtable_test.cc.cu
@@ -1841,7 +1841,7 @@ void test_evict_strategy_lfu_basic(size_t max_hbm_for_vectors) {
       CUDA_CHECK(cudaMemcpy(d_vectors_temp, h_vectors_base.data(),
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyHostToDevice));
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->insert_or_assign(BASE_KEY_NUM, d_keys_temp, d_vectors_temp,
                               d_scores_temp, stream);
       CUDA_CHECK(cudaStreamSynchronize(stream));
@@ -1880,7 +1880,7 @@ void test_evict_strategy_lfu_basic(size_t max_hbm_for_vectors) {
       CUDA_CHECK(cudaMemcpy(d_vectors_temp, h_vectors_test.data(),
                             TEST_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyHostToDevice));
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->insert_or_assign(TEST_KEY_NUM, d_keys_temp, d_vectors_temp,
                               d_scores_temp, stream);
       CUDA_CHECK(cudaStreamSynchronize(stream));
@@ -2012,7 +2012,7 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors) {
                             cudaMemcpyHostToDevice));
       S start_ts =
           (test_util::host_nano<S>(stream) >> RSHIFT_ON_NANO) & 0xFFFFFFFF;
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->insert_or_assign(BASE_KEY_NUM, d_keys_temp, d_vectors_temp,
                               nullptr, stream);
       CUDA_CHECK(cudaStreamSynchronize(stream));
@@ -2060,7 +2060,7 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors) {
                             cudaMemcpyHostToDevice));
       S start_ts =
           (test_util::host_nano<S>(stream) >> RSHIFT_ON_NANO) & 0xFFFFFFFF;
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->insert_or_assign(TEST_KEY_NUM, d_keys_temp, d_vectors_temp,
                               nullptr, stream);
       CUDA_CHECK(cudaStreamSynchronize(stream));
@@ -2208,7 +2208,7 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors) {
       CUDA_CHECK(cudaMemcpy(d_vectors_temp, h_vectors_base.data(),
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyHostToDevice));
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->insert_or_assign(BASE_KEY_NUM, d_keys_temp, d_vectors_temp,
                               d_scores_temp, stream);
       CUDA_CHECK(cudaStreamSynchronize(stream));
@@ -2255,7 +2255,7 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors) {
       CUDA_CHECK(cudaMemcpy(d_vectors_temp, h_vectors_test.data(),
                             TEST_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyHostToDevice));
-      EvictStrategy::set_global_epoch(global_epoch);
+      table->set_global_epoch(global_epoch);
       table->insert_or_assign(TEST_KEY_NUM, d_keys_temp, d_vectors_temp,
                               d_scores_temp, stream);
       CUDA_CHECK(cudaStreamSynchronize(stream));

--- a/tests/save_and_load_test.cc.cu
+++ b/tests/save_and_load_test.cc.cu
@@ -79,7 +79,7 @@ void test_save_to_file() {
                    Table::evict_strategy == EvictStrategy::kEpochLru)
                       ? nullptr
                       : d_scores;
-  EvictStrategy::set_global_epoch(global_epoch);
+  table_0->set_global_epoch(global_epoch);
   table_0->insert_or_assign(keynum, d_keys, d_vectors, temp_score, stream);
   printf("Fill table_0.\n");
   nv::merlin::LocalKVFile<K, V, S> file;


### PR DESCRIPTION
When setting the epoch evict strategy, the program will report an error when multi-threaded calls are encountered