### PR TITLE
[Revert] "[opt] Allocate hbm uniformly for buckets to avoid fragmentation."

### DIFF
--- a/include/merlin/types.cuh
+++ b/include/merlin/types.cuh
@@ -19,7 +19,6 @@
 #include <stddef.h>
 #include <cstdint>
 #include <cuda/std/semaphore>
-#include <vector>
 #include "debug.hpp"
 
 namespace nv {
@@ -215,7 +214,6 @@ struct Table {
   int slots_number = 0;                  // unused
   int device_id = 0;                     // Device id
   int tile_size;
-  std::vector<uint8_t*> buckets_address;
 };
 
 template <class K, class S>


### PR DESCRIPTION
- Considering the potential performance issue and no need to avoid the allocator retry log issue of upstream framework(TF), we revert the PR.
