### PR TITLE
[test] Missing header in test case

### DIFF
--- a/tests/test_util.cuh
+++ b/tests/test_util.cuh
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <algorithm>
+#include <iomanip>
 #include <iostream>
 #include <random>
 #include <string>


### PR DESCRIPTION
Fixed std::scientific was undefined when compiling test cases.
gcc: 9.2.1
cuda: 12.3