### PR TITLE
[Fix] corner case of find(V**) and find_or_insert(V**)'s result

### DIFF
--- a/benchmark/benchmark_util.cuh
+++ b/benchmark/benchmark_util.cuh
@@ -202,7 +202,9 @@ __global__ void read_from_ptr_kernel(const V* const* __restrict src,
   for (size_t t = tid; t < N; t += blockDim.x * gridDim.x) {
     int vec_index = int(t / dim);
     int dim_index = t % dim;
-    dst[vec_index * dim + dim_index] = src[vec_index][dim_index];
+    if (src[vec_index]) {
+      dst[vec_index * dim + dim_index] = src[vec_index][dim_index];
+    }
   }
 }
 

--- a/include/merlin/core_kernels.cuh
+++ b/include/merlin/core_kernels.cuh
@@ -1101,7 +1101,6 @@ __global__ void size_if_kernel(const Table<K, V, S>* __restrict table,
                                Bucket<K, V, S>* buckets, const K pattern,
                                const S threshold, size_t* d_counter) {
   extern __shared__ unsigned char s[];
-  KVM<K, V, S>* const block_tuples{reinterpret_cast<KVM<K, V, S>*>(s)};
 
   const size_t bucket_max_size{table->bucket_max_size};
 

--- a/include/merlin_hashtable.cuh
+++ b/include/merlin_hashtable.cuh
@@ -2378,8 +2378,6 @@ class HashTable : public HashTableBase<K, V, S> {
       return;
     }
 
-    CUDA_CHECK(cudaMemsetAsync(founds, 0, n * sizeof(bool), stream));
-
     read_shared_lock lock(mutex_, stream);
 
     constexpr uint32_t MinBucketCapacityFilter = sizeof(VecD_Load) / sizeof(D);

--- a/tests/find_or_insert_ptr_lock_test.cc.cu
+++ b/tests/find_or_insert_ptr_lock_test.cc.cu
@@ -65,7 +65,6 @@ void find_or_insert_safe_ptr(T* table, uint64_t KEY_NUM, K* d_keys, S* d_scores,
   CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
   CUDA_CHECK(cudaMalloc(&d_key_ptrs, KEY_NUM * sizeof(K*)));
 
-  test_util::array2ptr(d_vectors_ptr, d_vectors, dim, KEY_NUM, stream);
   table->find_or_insert(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores,
                         stream, true, false, d_key_ptrs);
   test_util::read_or_write_ptr(d_vectors_ptr, d_vectors, d_found, dim, KEY_NUM,
@@ -156,8 +155,6 @@ void test_basic(size_t max_hbm_for_vectors, int key_start = 0) {
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -257,8 +254,6 @@ void test_basic(size_t max_hbm_for_vectors, int key_start = 0) {
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -514,8 +509,6 @@ void test_erase_if_pred(size_t max_hbm_for_vectors, int key_start = 0) {
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -656,8 +649,6 @@ void test_rehash(size_t max_hbm_for_vectors, int key_start = 0) {
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, BUCKET_MAX_SIZE * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim,
-                           BUCKET_MAX_SIZE, stream);
       table->find(BUCKET_MAX_SIZE, d_keys, d_vectors_ptr, d_found, d_scores,
                   stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim,
@@ -806,8 +797,6 @@ void test_rehash_on_big_batch(size_t max_hbm_for_vectors, int key_start = 0) {
   {
     V** d_vectors_ptr = nullptr;
     CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-    test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                         stream);
     table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores, stream);
     test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                              stream);
@@ -927,8 +916,6 @@ void test_dynamic_rehash_on_multi_threads(size_t max_hbm_for_vectors,
       {
         V** d_vectors_ptr = nullptr;
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-        test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                             stream);
         table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr, stream);
         test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                  stream);
@@ -1077,8 +1064,6 @@ void test_export_batch_if(size_t max_hbm_for_vectors, int key_start = 0) {
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -1265,8 +1250,6 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
         CUDA_CHECK(cudaMalloc(&d_found, BASE_KEY_NUM * sizeof(bool)));
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, BASE_KEY_NUM * sizeof(V*)));
         CUDA_CHECK(cudaMalloc(&d_key_ptrs, BASE_KEY_NUM * sizeof(K*)));
-        test_util::array2ptr(d_vectors_ptr, d_vectors_temp, options.dim,
-                             BASE_KEY_NUM, stream);
         start_ts = test_util::host_nano<S>(stream);
         table->find_or_insert(BASE_KEY_NUM, d_keys_temp, d_vectors_ptr, d_found,
                               nullptr, stream, true, false, d_key_ptrs);
@@ -1330,8 +1313,6 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
         CUDA_CHECK(cudaMalloc(&d_found, TEST_KEY_NUM * sizeof(bool)));
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, TEST_KEY_NUM * sizeof(V*)));
         CUDA_CHECK(cudaMalloc(&d_key_ptrs, TEST_KEY_NUM * sizeof(K*)));
-        test_util::array2ptr(d_vectors_ptr, d_vectors_temp, options.dim,
-                             TEST_KEY_NUM, stream);
         table->find_or_insert(TEST_KEY_NUM, d_keys_temp, d_vectors_ptr, d_found,
                               nullptr, stream, true, false, d_key_ptrs);
         test_util::read_or_write_ptr(d_vectors_ptr, d_vectors_temp, d_found,
@@ -1667,8 +1648,6 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, BASE_KEY_NUM * sizeof(V*)));
         CUDA_CHECK(cudaMalloc(&d_key_ptrs, BASE_KEY_NUM * sizeof(K*)));
 
-        test_util::array2ptr(d_vectors_ptr, d_vectors_temp, options.dim,
-                             BASE_KEY_NUM, stream);
         start_ts =
             (test_util::host_nano<S>(stream) >> RSHIFT_ON_NANO) & 0xFFFFFFFF;
         table->set_global_epoch(global_epoch);
@@ -1739,8 +1718,6 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, TEST_KEY_NUM * sizeof(V*)));
         CUDA_CHECK(cudaMalloc(&d_key_ptrs, TEST_KEY_NUM * sizeof(K*)));
 
-        test_util::array2ptr(d_vectors_ptr, d_vectors_temp, options.dim,
-                             TEST_KEY_NUM, stream);
         table->find_or_insert(TEST_KEY_NUM, d_keys_temp, d_vectors_ptr, d_found,
                               nullptr, stream, true, false, d_key_ptrs);
         test_util::read_or_write_ptr(d_vectors_ptr, d_vectors_temp, d_found,
@@ -1909,8 +1886,6 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors,
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, BASE_KEY_NUM * sizeof(V*)));
         CUDA_CHECK(cudaMalloc(&d_key_ptrs, BASE_KEY_NUM * sizeof(K*)));
 
-        test_util::array2ptr(d_vectors_ptr, d_vectors_temp, options.dim,
-                             BASE_KEY_NUM, stream);
         table->set_global_epoch(global_epoch);
         table->find_or_insert(BASE_KEY_NUM, d_keys_temp, d_vectors_ptr, d_found,
                               d_scores_temp, stream, true, false, d_key_ptrs);
@@ -1978,8 +1953,6 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors,
         CUDA_CHECK(cudaMalloc(&d_found, TEST_KEY_NUM * sizeof(bool)));
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, TEST_KEY_NUM * sizeof(V*)));
         CUDA_CHECK(cudaMalloc(&d_key_ptrs, TEST_KEY_NUM * sizeof(K*)));
-        test_util::array2ptr(d_vectors_ptr, d_vectors_temp, options.dim,
-                             TEST_KEY_NUM, stream);
         table->find_or_insert(TEST_KEY_NUM, d_keys_temp, d_vectors_ptr, d_found,
                               d_scores_temp, stream, true, false, d_key_ptrs);
         test_util::read_or_write_ptr(d_vectors_ptr, d_vectors_temp, d_found,
@@ -2639,8 +2612,6 @@ void test_find_or_insert_multi_threads(size_t max_hbm_for_vectors,
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -2670,8 +2641,6 @@ void test_find_or_insert_multi_threads(size_t max_hbm_for_vectors,
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -2802,8 +2771,6 @@ void test_find_or_insert_multi_threads(size_t max_hbm_for_vectors,
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);

--- a/tests/find_or_insert_ptr_test.cc.cu
+++ b/tests/find_or_insert_ptr_test.cc.cu
@@ -125,8 +125,6 @@ void test_basic(size_t max_hbm_for_vectors, int key_start = 0) {
       CUDA_CHECK(cudaMalloc(&d_found, KEY_NUM * sizeof(bool)));
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
 
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find_or_insert(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores,
                             stream);
       test_util::read_or_write_ptr(d_vectors_ptr, d_vectors, d_found,
@@ -148,8 +146,6 @@ void test_basic(size_t max_hbm_for_vectors, int key_start = 0) {
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -239,8 +235,6 @@ void test_basic(size_t max_hbm_for_vectors, int key_start = 0) {
       bool* d_found;
       CUDA_CHECK(cudaMalloc(&d_found, KEY_NUM * sizeof(bool)));
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find_or_insert(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores,
                             stream);
       test_util::read_or_write_ptr(d_vectors_ptr, d_vectors, d_found,
@@ -262,8 +256,6 @@ void test_basic(size_t max_hbm_for_vectors, int key_start = 0) {
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -402,8 +394,6 @@ void test_basic_when_full(size_t max_hbm_for_vectors, int key_start = 0) {
       bool* d_found;
       CUDA_CHECK(cudaMalloc(&d_found, KEY_NUM * sizeof(bool)));
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find_or_insert(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores,
                             stream);
       test_util::read_or_write_ptr(d_vectors_ptr, d_vectors, d_found,
@@ -428,8 +418,6 @@ void test_basic_when_full(size_t max_hbm_for_vectors, int key_start = 0) {
       bool* d_found;
       CUDA_CHECK(cudaMalloc(&d_found, KEY_NUM * sizeof(bool)));
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find_or_insert(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores,
                             stream);
       test_util::read_or_write_ptr(d_vectors_ptr, d_vectors, d_found,
@@ -528,8 +516,6 @@ void test_erase_if_pred(size_t max_hbm_for_vectors, int key_start = 0) {
       bool* d_found;
       CUDA_CHECK(cudaMalloc(&d_found, KEY_NUM * sizeof(bool)));
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find_or_insert(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores,
                             stream);
       test_util::read_or_write_ptr(d_vectors_ptr, d_vectors, d_found,
@@ -558,8 +544,6 @@ void test_erase_if_pred(size_t max_hbm_for_vectors, int key_start = 0) {
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -679,8 +663,6 @@ void test_rehash(size_t max_hbm_for_vectors, int key_start = 0) {
       bool* d_found;
       CUDA_CHECK(cudaMalloc(&d_found, KEY_NUM * sizeof(bool)));
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find_or_insert(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores,
                             stream);
       test_util::read_or_write_ptr(d_vectors_ptr, d_vectors, d_found,
@@ -713,8 +695,6 @@ void test_rehash(size_t max_hbm_for_vectors, int key_start = 0) {
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, BUCKET_MAX_SIZE * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim,
-                           BUCKET_MAX_SIZE, stream);
       table->find(BUCKET_MAX_SIZE, d_keys, d_vectors_ptr, d_found, d_scores,
                   stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim,
@@ -836,8 +816,6 @@ void test_rehash_on_big_batch(size_t max_hbm_for_vectors, int key_start = 0) {
     bool* d_found;
     CUDA_CHECK(cudaMalloc(&d_found, INIT_KEY_NUM * sizeof(bool)));
     CUDA_CHECK(cudaMalloc(&d_vectors_ptr, INIT_KEY_NUM * sizeof(V*)));
-    test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, INIT_KEY_NUM,
-                         stream);
     table->find_or_insert(INIT_KEY_NUM, d_keys, d_vectors_ptr, d_found,
                           d_scores, stream);
     test_util::read_or_write_ptr(d_vectors_ptr, d_vectors, d_found, options.dim,
@@ -860,8 +838,6 @@ void test_rehash_on_big_batch(size_t max_hbm_for_vectors, int key_start = 0) {
     bool* d_found;
     CUDA_CHECK(cudaMalloc(&d_found, KEY_NUM * sizeof(bool)));
     CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-    test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                         stream);
     table->find_or_insert(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores,
                           stream);
     test_util::read_or_write_ptr(d_vectors_ptr, d_vectors, d_found, options.dim,
@@ -889,8 +865,6 @@ void test_rehash_on_big_batch(size_t max_hbm_for_vectors, int key_start = 0) {
   {
     V** d_vectors_ptr = nullptr;
     CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-    test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                         stream);
     table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores, stream);
     test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                              stream);
@@ -1006,8 +980,6 @@ void test_dynamic_rehash_on_multi_threads(size_t max_hbm_for_vectors,
         bool* d_found;
         CUDA_CHECK(cudaMalloc(&d_found, KEY_NUM * sizeof(bool)));
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-        test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                             stream);
         table->find_or_insert(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr,
                               stream);
         test_util::read_or_write_ptr(d_vectors_ptr, d_vectors, d_found,
@@ -1023,8 +995,6 @@ void test_dynamic_rehash_on_multi_threads(size_t max_hbm_for_vectors,
       {
         V** d_vectors_ptr = nullptr;
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-        test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                             stream);
         table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr, stream);
         test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                  stream);
@@ -1160,8 +1130,6 @@ void test_export_batch_if(size_t max_hbm_for_vectors, int key_start = 0) {
       bool* d_found;
       CUDA_CHECK(cudaMalloc(&d_found, KEY_NUM * sizeof(bool)));
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find_or_insert(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr,
                             stream);
       test_util::read_or_write_ptr(d_vectors_ptr, d_vectors, d_found,
@@ -1186,8 +1154,6 @@ void test_export_batch_if(size_t max_hbm_for_vectors, int key_start = 0) {
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -1359,8 +1325,6 @@ void test_basic_for_cpu_io(int key_start = 0) {
       bool* d_found;
       CUDA_CHECK(cudaMalloc(&d_found, KEY_NUM * sizeof(bool)));
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find_or_insert(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores,
                             stream);
       test_util::read_or_write_ptr(d_vectors_ptr, d_vectors, d_found,
@@ -1387,8 +1351,6 @@ void test_basic_for_cpu_io(int key_start = 0) {
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -1429,8 +1391,6 @@ void test_basic_for_cpu_io(int key_start = 0) {
       bool* d_found;
       CUDA_CHECK(cudaMalloc(&d_found, KEY_NUM * sizeof(bool)));
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find_or_insert(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores,
                             stream);
       test_util::read_or_write_ptr(d_vectors_ptr, d_vectors, d_found,
@@ -1551,8 +1511,6 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
         bool* d_found;
         CUDA_CHECK(cudaMalloc(&d_found, BASE_KEY_NUM * sizeof(bool)));
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, BASE_KEY_NUM * sizeof(V*)));
-        test_util::array2ptr(d_vectors_ptr, d_vectors_temp, options.dim,
-                             BASE_KEY_NUM, stream);
         start_ts = test_util::host_nano<S>(stream);
         table->find_or_insert(BASE_KEY_NUM, d_keys_temp, d_vectors_ptr, d_found,
                               nullptr, stream);
@@ -1611,8 +1569,6 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
         bool* d_found;
         CUDA_CHECK(cudaMalloc(&d_found, TEST_KEY_NUM * sizeof(bool)));
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, TEST_KEY_NUM * sizeof(V*)));
-        test_util::array2ptr(d_vectors_ptr, d_vectors_temp, options.dim,
-                             TEST_KEY_NUM, stream);
         table->find_or_insert(TEST_KEY_NUM, d_keys_temp, d_vectors_ptr, d_found,
                               nullptr, stream);
         test_util::read_or_write_ptr(d_vectors_ptr, d_vectors_temp, d_found,
@@ -1765,8 +1721,6 @@ void test_evict_strategy_lfu_basic(size_t max_hbm_for_vectors,
         bool* d_found;
         CUDA_CHECK(cudaMalloc(&d_found, BASE_KEY_NUM * sizeof(bool)));
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, BASE_KEY_NUM * sizeof(V*)));
-        test_util::array2ptr(d_vectors_ptr, d_vectors_temp, options.dim,
-                             BASE_KEY_NUM, stream);
         table->find_or_insert(BASE_KEY_NUM, d_keys_temp, d_vectors_ptr, d_found,
                               d_scores_temp, stream);
         test_util::read_or_write_ptr(d_vectors_ptr, d_vectors_temp, d_found,
@@ -1817,8 +1771,6 @@ void test_evict_strategy_lfu_basic(size_t max_hbm_for_vectors,
         bool* d_found;
         CUDA_CHECK(cudaMalloc(&d_found, TEST_KEY_NUM * sizeof(bool)));
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, TEST_KEY_NUM * sizeof(V*)));
-        test_util::array2ptr(d_vectors_ptr, d_vectors_temp, options.dim,
-                             TEST_KEY_NUM, stream);
         table->find_or_insert(TEST_KEY_NUM, d_keys_temp, d_vectors_ptr, d_found,
                               d_scores_temp, stream);
         test_util::read_or_write_ptr(d_vectors_ptr, d_vectors_temp, d_found,
@@ -1965,8 +1917,6 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
         bool* d_found;
         CUDA_CHECK(cudaMalloc(&d_found, BASE_KEY_NUM * sizeof(bool)));
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, BASE_KEY_NUM * sizeof(V*)));
-        test_util::array2ptr(d_vectors_ptr, d_vectors_temp, options.dim,
-                             BASE_KEY_NUM, stream);
         start_ts =
             (test_util::host_nano<S>(stream) >> RSHIFT_ON_NANO) & 0xFFFFFFFF;
         table->set_global_epoch(global_epoch);
@@ -2031,8 +1981,6 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
         bool* d_found;
         CUDA_CHECK(cudaMalloc(&d_found, TEST_KEY_NUM * sizeof(bool)));
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, TEST_KEY_NUM * sizeof(V*)));
-        test_util::array2ptr(d_vectors_ptr, d_vectors_temp, options.dim,
-                             TEST_KEY_NUM, stream);
         table->find_or_insert(TEST_KEY_NUM, d_keys_temp, d_vectors_ptr, d_found,
                               nullptr, stream);
         test_util::read_or_write_ptr(d_vectors_ptr, d_vectors_temp, d_found,
@@ -2194,8 +2142,6 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors,
         bool* d_found;
         CUDA_CHECK(cudaMalloc(&d_found, BASE_KEY_NUM * sizeof(bool)));
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, BASE_KEY_NUM * sizeof(V*)));
-        test_util::array2ptr(d_vectors_ptr, d_vectors_temp, options.dim,
-                             BASE_KEY_NUM, stream);
         table->set_global_epoch(global_epoch);
         table->find_or_insert(BASE_KEY_NUM, d_keys_temp, d_vectors_ptr, d_found,
                               d_scores_temp, stream);
@@ -2258,8 +2204,6 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors,
         bool* d_found;
         CUDA_CHECK(cudaMalloc(&d_found, TEST_KEY_NUM * sizeof(bool)));
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, TEST_KEY_NUM * sizeof(V*)));
-        test_util::array2ptr(d_vectors_ptr, d_vectors_temp, options.dim,
-                             TEST_KEY_NUM, stream);
         table->find_or_insert(TEST_KEY_NUM, d_keys_temp, d_vectors_ptr, d_found,
                               d_scores_temp, stream);
         test_util::read_or_write_ptr(d_vectors_ptr, d_vectors_temp, d_found,
@@ -2431,8 +2375,6 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
         bool* d_found;
         CUDA_CHECK(cudaMalloc(&d_found, BASE_KEY_NUM * sizeof(bool)));
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, BASE_KEY_NUM * sizeof(V*)));
-        test_util::array2ptr(d_vectors_ptr, d_vectors_temp, options.dim,
-                             BASE_KEY_NUM, stream);
         table->find_or_insert(BASE_KEY_NUM, d_keys_temp, d_vectors_ptr, d_found,
                               d_scores_temp, stream);
         test_util::read_or_write_ptr(d_vectors_ptr, d_vectors_temp, d_found,
@@ -2488,8 +2430,6 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
         bool* d_found;
         CUDA_CHECK(cudaMalloc(&d_found, TEST_KEY_NUM * sizeof(bool)));
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, TEST_KEY_NUM * sizeof(V*)));
-        test_util::array2ptr(d_vectors_ptr, d_vectors_temp, options.dim,
-                             TEST_KEY_NUM, stream);
         table->find_or_insert(TEST_KEY_NUM, d_keys_temp, d_vectors_ptr, d_found,
                               d_scores_temp, stream);
         test_util::read_or_write_ptr(d_vectors_ptr, d_vectors_temp, d_found,
@@ -2645,8 +2585,6 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors,
         bool* d_found;
         CUDA_CHECK(cudaMalloc(&d_found, BASE_KEY_NUM * sizeof(bool)));
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, BASE_KEY_NUM * sizeof(V*)));
-        test_util::array2ptr(d_vectors_ptr, d_vectors_temp, options.dim,
-                             BASE_KEY_NUM, stream);
         table->find_or_insert(BASE_KEY_NUM, d_keys_temp, d_vectors_ptr, d_found,
                               d_scores_temp, stream);
         test_util::read_or_write_ptr(d_vectors_ptr, d_vectors_temp, d_found,
@@ -2702,8 +2640,6 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors,
         bool* d_found;
         CUDA_CHECK(cudaMalloc(&d_found, TEST_KEY_NUM * sizeof(bool)));
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, TEST_KEY_NUM * sizeof(V*)));
-        test_util::array2ptr(d_vectors_ptr, d_vectors_temp, options.dim,
-                             TEST_KEY_NUM, stream);
         table->find_or_insert(TEST_KEY_NUM, d_keys_temp, d_vectors_ptr, d_found,
                               d_scores_temp, stream);
         test_util::read_or_write_ptr(d_vectors_ptr, d_vectors_temp, d_found,
@@ -2848,8 +2784,6 @@ void test_evict_strategy_customized_correct_rate(size_t max_hbm_for_vectors,
           bool* d_found;
           CUDA_CHECK(cudaMalloc(&d_found, BATCH_SIZE * sizeof(bool)));
           CUDA_CHECK(cudaMalloc(&d_vectors_ptr, BATCH_SIZE * sizeof(V*)));
-          test_util::array2ptr(d_vectors_ptr, d_vectors_temp, options.dim,
-                               BATCH_SIZE, stream);
           table->find_or_insert(BATCH_SIZE, d_keys_temp, d_vectors_ptr, d_found,
                                 d_scores_temp, stream);
           test_util::read_or_write_ptr(d_vectors_ptr, d_vectors_temp, d_found,
@@ -2976,8 +2910,6 @@ void test_find_or_insert_multi_threads(size_t max_hbm_for_vectors,
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -3004,8 +2936,6 @@ void test_find_or_insert_multi_threads(size_t max_hbm_for_vectors,
       bool* d_found;
       CUDA_CHECK(cudaMalloc(&d_found, KEY_NUM * sizeof(bool)));
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find_or_insert(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr,
                             stream);
       test_util::read_or_write_ptr(d_vectors_ptr, d_vectors, d_found,
@@ -3021,8 +2951,6 @@ void test_find_or_insert_multi_threads(size_t max_hbm_for_vectors,
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -3147,8 +3075,6 @@ void test_find_or_insert_multi_threads(size_t max_hbm_for_vectors,
       bool* d_found;
       CUDA_CHECK(cudaMalloc(&d_found, KEY_NUM * sizeof(bool)));
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find_or_insert(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr,
                             stream);
       test_util::read_or_write_ptr(d_vectors_ptr, d_vectors, d_found,
@@ -3166,8 +3092,6 @@ void test_find_or_insert_multi_threads(size_t max_hbm_for_vectors,
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -3346,7 +3270,6 @@ void CheckFindOrInsertValues(Table* table, K* keys, V* values, S* scores,
     bool* d_found;
     CUDA_CHECK(cudaMalloc(&d_found, len * sizeof(bool)));
     CUDA_CHECK(cudaMalloc(&d_vectors_ptr, len * sizeof(V*)));
-    test_util::array2ptr(d_vectors_ptr, values, dim, len, stream);
     table->find_or_insert(len, keys, d_vectors_ptr, d_found, nullptr, stream);
     test_util::read_or_write_ptr(d_vectors_ptr, values, d_found, dim, len,
                                  stream);
@@ -3517,8 +3440,6 @@ void test_duplicated_keys(size_t max_hbm_for_vectors, size_t key_start = 0) {
       CUDA_CHECK(cudaMalloc(&d_found, KEY_NUM * sizeof(bool)));
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
 
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find_or_insert(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores,
                             stream, false);
       test_util::read_or_write_ptr(d_vectors_ptr, d_vectors, d_found,

--- a/tests/find_or_insert_test.cc.cu
+++ b/tests/find_or_insert_test.cc.cu
@@ -131,8 +131,6 @@ void test_basic(size_t max_hbm_for_vectors, int key_start = 0) {
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -230,8 +228,6 @@ void test_basic(size_t max_hbm_for_vectors, int key_start = 0) {
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -501,8 +497,6 @@ void test_erase_if_pred(size_t max_hbm_for_vectors, int key_start = 0) {
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -641,8 +635,6 @@ void test_rehash(size_t max_hbm_for_vectors, int key_start = 0) {
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, BUCKET_MAX_SIZE * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim,
-                           BUCKET_MAX_SIZE, stream);
       table->find(BUCKET_MAX_SIZE, d_keys, d_vectors_ptr, d_found, d_scores,
                   stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim,
@@ -788,8 +780,6 @@ void test_rehash_on_big_batch(size_t max_hbm_for_vectors, int key_start = 0) {
   {
     V** d_vectors_ptr = nullptr;
     CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-    test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                         stream);
     table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, d_scores, stream);
     test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                              stream);
@@ -907,8 +897,6 @@ void test_dynamic_rehash_on_multi_threads(size_t max_hbm_for_vectors,
       {
         V** d_vectors_ptr = nullptr;
         CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-        test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                             stream);
         table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr, stream);
         test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                  stream);
@@ -1056,8 +1044,6 @@ void test_export_batch_if(size_t max_hbm_for_vectors, int key_start = 0) {
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -1241,8 +1227,6 @@ void test_basic_for_cpu_io(int key_start = 0) {
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -2966,8 +2950,6 @@ void test_find_or_insert_multi_threads(size_t max_hbm_for_vectors,
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -2996,8 +2978,6 @@ void test_find_or_insert_multi_threads(size_t max_hbm_for_vectors,
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);
@@ -3126,8 +3106,6 @@ void test_find_or_insert_multi_threads(size_t max_hbm_for_vectors,
     {
       V** d_vectors_ptr = nullptr;
       CUDA_CHECK(cudaMalloc(&d_vectors_ptr, KEY_NUM * sizeof(V*)));
-      test_util::array2ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
-                           stream);
       table->find(KEY_NUM, d_keys, d_vectors_ptr, d_found, nullptr, stream);
       test_util::read_from_ptr(d_vectors_ptr, d_vectors, options.dim, KEY_NUM,
                                stream);

--- a/tests/test_util.cuh
+++ b/tests/test_util.cuh
@@ -749,7 +749,9 @@ __global__ void read_from_ptr_kernel(const V* const* __restrict src,
   for (size_t t = tid; t < N; t += blockDim.x * gridDim.x) {
     int vec_index = int(t / dim);
     int dim_index = t % dim;
-    dst[vec_index * dim + dim_index] = src[vec_index][dim_index];
+    if (src[vec_index]) {
+      dst[vec_index * dim + dim_index] = src[vec_index][dim_index];
+    }
   }
 }
 


### PR DESCRIPTION
  - for find(V**), reset value_ptr to nullptr when not found.
  - for find_or_insert(V**), reset founds[i] to false when insert failed.
  - remove reset founds in find(V**), because founds will be reset in later kernel.
  - remove unused local var in size_if_kernel