### PR TITLE
[Opt] Rename `succeededs` to `success` — the current name is not a valid word

### DIFF
--- a/include/merlin_hashtable.cuh
+++ b/include/merlin_hashtable.cuh
@@ -1797,7 +1797,7 @@ class HashTable : public HashTableBase<K, V, S> {
    * @param locked_key_ptrs The pointers of locked keys in the table with shape
    * (n).
    * @param keys The keys to search on GPU-accessible memory with shape (n).
-   * @param succeededs The status that indicates if the lock operation is
+   * @param success The status that indicates if the lock operation is
    * succeed.
    * @param stream The CUDA stream that is used to execute the operation.
    *
@@ -1805,7 +1805,7 @@ class HashTable : public HashTableBase<K, V, S> {
   void lock_keys(const size_type n,
                  key_type const* keys,        // (n)
                  key_type** locked_key_ptrs,  // (n)
-                 bool* succeededs = nullptr,  // (n)
+                 bool* success = nullptr,     // (n)
                  cudaStream_t stream = 0) {
     if (n == 0) {
       return;
@@ -1823,7 +1823,7 @@ class HashTable : public HashTableBase<K, V, S> {
     lock_kernel_with_filter<key_type, value_type, score_type>
         <<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
             table_->buckets, table_->buckets_num, options_.max_bucket_size,
-            options_.dim, keys, locked_key_ptrs, succeededs, n);
+            options_.dim, keys, locked_key_ptrs, success, n);
     CudaCheckError();
   }
 
@@ -1837,14 +1837,14 @@ class HashTable : public HashTableBase<K, V, S> {
    * @param locked_key_ptrs The pointers of locked keys in the table with shape
    * (n).
    * @param keys The keys to search on GPU-accessible memory with shape (n).
-   * @param succeededs The status that indicates if the unlock operation is
+   * @param success The status that indicates if the unlock operation is
    * succeed.
    * @param stream The CUDA stream that is used to execute the operation.
    *
    */
   void unlock_keys(const size_type n, key_type** locked_key_ptrs,  // (n)
                    const key_type* keys,                           // (n)
-                   bool* succeededs = nullptr,                     // (n)
+                   bool* success = nullptr,                        // (n)
                    cudaStream_t stream = 0) {
     if (n == 0) {
       return;
@@ -1856,7 +1856,7 @@ class HashTable : public HashTableBase<K, V, S> {
     /// TODO: check the key belongs to the bucket.
     unlock_keys_kernel<key_type>
         <<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
-            n, locked_key_ptrs, keys, succeededs);
+            n, locked_key_ptrs, keys, success);
   }
 
   /**


### PR DESCRIPTION
- `results` and `statuses` may be other reasonable options as well.