### PR TITLE
[Fix] test compilation with CUDA 12.x stricter constexpr requirements

### DIFF
--- a/include/merlin/allocator.cuh
+++ b/include/merlin/allocator.cuh
@@ -59,8 +59,8 @@ class BaseAllocator {
 
 class DefaultAllocator : public virtual BaseAllocator {
  public:
-  DefaultAllocator(){};
-  ~DefaultAllocator() override{};
+  DefaultAllocator() {};
+  ~DefaultAllocator() override {};
 
   void alloc(const MemoryType type, void** ptr, size_t size,
              unsigned int pinned_flags = cudaHostAllocDefault) override {

--- a/tests/accum_or_assign_test.cc.cu
+++ b/tests/accum_or_assign_test.cc.cu
@@ -933,7 +933,8 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors) {
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
   constexpr float true_ratio = 0.5;
 
@@ -945,19 +946,19 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors) {
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kLru>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
-  std::array<bool, BASE_KEY_NUM> h_accum_or_assigns_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
+  std::vector<uint8_t> h_accum_or_assigns_base(BASE_KEY_NUM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
-  std::array<bool, TEST_KEY_NUM> h_accum_or_assigns_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
+  std::vector<uint8_t> h_accum_or_assigns_test(TEST_KEY_NUM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -971,13 +972,13 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors) {
 
   CUDA_CHECK(cudaMalloc(&d_accum_or_assigns_temp, TEMP_KEY_NUM * sizeof(bool)));
 
-  test_util::create_random_bools<K>(h_accum_or_assigns_base.data(),
+  test_util::create_random_bools<K>(reinterpret_cast<bool*>(h_accum_or_assigns_base.data()),
                                     BASE_KEY_NUM, true_ratio);
   test_util::create_keys_in_one_buckets<K, S, V, DIM>(
       h_keys_base.data(), h_scores_base.data(), h_vectors_base.data(),
       BASE_KEY_NUM, INIT_CAPACITY, BUCKET_MAX_SIZE, 1, 0, 0x3FFFFFFFFFFFFFFF);
 
-  test_util::create_random_bools<K>(h_accum_or_assigns_test.data(),
+  test_util::create_random_bools<K>(reinterpret_cast<bool*>(h_accum_or_assigns_test.data()),
                                     TEST_KEY_NUM, true_ratio);
   test_util::create_keys_in_one_buckets<K, S, V, DIM>(
       h_keys_test.data(), h_scores_test.data(), h_vectors_test.data(),
@@ -1020,7 +1021,7 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors) {
                             cudaMemcpyHostToDevice));
       CUDA_CHECK(
           cudaMemcpy(d_accum_or_assigns_temp, h_accum_or_assigns_base.data(),
-                     BASE_KEY_NUM * sizeof(bool), cudaMemcpyHostToDevice));
+                     BASE_KEY_NUM * sizeof(uint8_t), cudaMemcpyHostToDevice));
       S start_ts = test_util::host_nano<S>(stream);
       table->accum_or_assign(BASE_KEY_NUM, d_keys_temp, d_vectors_temp,
                              d_accum_or_assigns_temp, nullptr, stream);
@@ -1147,7 +1148,8 @@ void test_evict_strategy_lfu_basic(size_t max_hbm_for_vectors, int key_start) {
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 1024;
   constexpr float true_ratio = 0.5;
 
@@ -1159,19 +1161,19 @@ void test_evict_strategy_lfu_basic(size_t max_hbm_for_vectors, int key_start) {
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kLfu>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
-  std::array<bool, BASE_KEY_NUM> h_accum_or_assigns_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
+  std::vector<uint8_t> h_accum_or_assigns_base(BASE_KEY_NUM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
-  std::array<bool, TEST_KEY_NUM> h_accum_or_assigns_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
+  std::vector<uint8_t> h_accum_or_assigns_test(TEST_KEY_NUM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -1187,10 +1189,10 @@ void test_evict_strategy_lfu_basic(size_t max_hbm_for_vectors, int key_start) {
 
   CUDA_CHECK(cudaMalloc(&d_accum_or_assigns_temp, TEMP_KEY_NUM * sizeof(bool)));
 
-  test_util::create_random_bools<K>(h_accum_or_assigns_base.data(),
+  test_util::create_random_bools<K>(reinterpret_cast<bool*>(h_accum_or_assigns_base.data()),
                                     BASE_KEY_NUM, true_ratio);
 
-  test_util::create_random_bools<K>(h_accum_or_assigns_test.data(),
+  test_util::create_random_bools<K>(reinterpret_cast<bool*>(h_accum_or_assigns_test.data()),
                                     TEST_KEY_NUM, true_ratio);
 
   for (int i = 0; i < TEST_TIMES; i++) {
@@ -1245,7 +1247,7 @@ void test_evict_strategy_lfu_basic(size_t max_hbm_for_vectors, int key_start) {
                             cudaMemcpyHostToDevice));
       CUDA_CHECK(
           cudaMemcpy(d_accum_or_assigns_temp, h_accum_or_assigns_base.data(),
-                     BASE_KEY_NUM * sizeof(bool), cudaMemcpyHostToDevice));
+                     BASE_KEY_NUM * sizeof(uint8_t), cudaMemcpyHostToDevice));
 
       table->set_global_epoch(global_epoch);
       table->accum_or_assign(BASE_KEY_NUM, d_keys_temp, d_vectors_temp,
@@ -1374,7 +1376,8 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
   constexpr float true_ratio = 0.5;
 
@@ -1387,19 +1390,19 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kEpochLru>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
-  std::array<bool, BASE_KEY_NUM> h_accum_or_assigns_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
+  std::vector<uint8_t> h_accum_or_assigns_base(BASE_KEY_NUM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
-  std::array<bool, TEST_KEY_NUM> h_accum_or_assigns_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
+  std::vector<uint8_t> h_accum_or_assigns_test(TEST_KEY_NUM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -1413,13 +1416,13 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
 
   CUDA_CHECK(cudaMalloc(&d_accum_or_assigns_temp, TEMP_KEY_NUM * sizeof(bool)));
 
-  test_util::create_random_bools<K>(h_accum_or_assigns_base.data(),
+  test_util::create_random_bools<K>(reinterpret_cast<bool*>(h_accum_or_assigns_base.data()),
                                     BASE_KEY_NUM, true_ratio);
   test_util::create_keys_in_one_buckets<K, S, V, DIM>(
       h_keys_base.data(), h_scores_base.data(), h_vectors_base.data(),
       BASE_KEY_NUM, INIT_CAPACITY, BUCKET_MAX_SIZE, 1, 0, 0x3FFFFFFFFFFFFFFF);
 
-  test_util::create_random_bools<K>(h_accum_or_assigns_test.data(),
+  test_util::create_random_bools<K>(reinterpret_cast<bool*>(h_accum_or_assigns_test.data()),
                                     TEST_KEY_NUM, true_ratio);
   test_util::create_keys_in_one_buckets<K, S, V, DIM>(
       h_keys_test.data(), h_scores_test.data(), h_vectors_test.data(),
@@ -1463,7 +1466,7 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
                             cudaMemcpyHostToDevice));
       CUDA_CHECK(
           cudaMemcpy(d_accum_or_assigns_temp, h_accum_or_assigns_base.data(),
-                     BASE_KEY_NUM * sizeof(bool), cudaMemcpyHostToDevice));
+                     BASE_KEY_NUM * sizeof(uint8_t), cudaMemcpyHostToDevice));
       S start_ts =
           (test_util::host_nano<S>(stream) >> RSHIFT_ON_NANO) & 0xFFFFFFFF;
       table->set_global_epoch(global_epoch);
@@ -1600,7 +1603,8 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 1024;
   constexpr float true_ratio = 0.5;
 
@@ -1613,19 +1617,19 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kEpochLfu>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
-  std::array<bool, BASE_KEY_NUM> h_accum_or_assigns_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
+  std::vector<uint8_t> h_accum_or_assigns_base(BASE_KEY_NUM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
-  std::array<bool, TEST_KEY_NUM> h_accum_or_assigns_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
+  std::vector<uint8_t> h_accum_or_assigns_test(TEST_KEY_NUM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -1641,10 +1645,10 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors,
 
   CUDA_CHECK(cudaMalloc(&d_accum_or_assigns_temp, TEMP_KEY_NUM * sizeof(bool)));
 
-  test_util::create_random_bools<K>(h_accum_or_assigns_base.data(),
+  test_util::create_random_bools<K>(reinterpret_cast<bool*>(h_accum_or_assigns_base.data()),
                                     BASE_KEY_NUM, true_ratio);
 
-  test_util::create_random_bools<K>(h_accum_or_assigns_test.data(),
+  test_util::create_random_bools<K>(reinterpret_cast<bool*>(h_accum_or_assigns_test.data()),
                                     TEST_KEY_NUM, true_ratio);
 
   test_util::create_keys_in_one_buckets_lfu<K, S, V, DIM>(
@@ -1706,7 +1710,7 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors,
                             cudaMemcpyHostToDevice));
       CUDA_CHECK(
           cudaMemcpy(d_accum_or_assigns_temp, h_accum_or_assigns_base.data(),
-                     BASE_KEY_NUM * sizeof(bool), cudaMemcpyHostToDevice));
+                     BASE_KEY_NUM * sizeof(uint8_t), cudaMemcpyHostToDevice));
 
       table->set_global_epoch(global_epoch);
       table->accum_or_assign(BASE_KEY_NUM, d_keys_temp, d_vectors_temp,
@@ -1866,7 +1870,8 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 128;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
   constexpr float true_ratio = 0.3;
 
@@ -1879,20 +1884,20 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
-  std::array<bool, BASE_KEY_NUM> h_accum_or_assigns_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
+  std::vector<uint8_t> h_accum_or_assigns_base(BASE_KEY_NUM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
-  std::array<bool, TEST_KEY_NUM> h_accum_or_assigns_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
+  std::vector<uint8_t> h_accum_or_assigns_test(TEST_KEY_NUM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
-  std::array<bool, TEMP_KEY_NUM> h_found_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
+  std::vector<uint8_t> h_found_temp(TEMP_KEY_NUM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -1908,9 +1913,9 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
   CUDA_CHECK(cudaMalloc(&d_accum_or_assigns_temp, TEMP_KEY_NUM * sizeof(bool)));
   CUDA_CHECK(cudaMalloc(&d_found_temp, TEMP_KEY_NUM * sizeof(bool)));
 
-  test_util::create_random_bools<K>(h_accum_or_assigns_base.data(),
+  test_util::create_random_bools<K>(reinterpret_cast<bool*>(h_accum_or_assigns_base.data()),
                                     BASE_KEY_NUM, true_ratio);
-  test_util::create_random_bools<K>(h_accum_or_assigns_test.data(),
+  test_util::create_random_bools<K>(reinterpret_cast<bool*>(h_accum_or_assigns_test.data()),
                                     TEST_KEY_NUM, true_ratio);
 
   test_util::create_keys_in_one_buckets<K, S, V, DIM>(
@@ -1961,7 +1966,7 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
                             cudaMemcpyHostToDevice));
       CUDA_CHECK(
           cudaMemcpy(d_accum_or_assigns_temp, h_accum_or_assigns_base.data(),
-                     BASE_KEY_NUM * sizeof(bool), cudaMemcpyHostToDevice));
+                     BASE_KEY_NUM * sizeof(uint8_t), cudaMemcpyHostToDevice));
       table->accum_or_assign(BASE_KEY_NUM, d_keys_temp, d_vectors_temp,
                              d_accum_or_assigns_temp, d_scores_temp, stream);
       CUDA_CHECK(cudaStreamSynchronize(stream));
@@ -2126,7 +2131,8 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 8;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 256;
   constexpr float base_true_ratio = 0.0f;
   constexpr float test_true_ratio = 0.5f;
@@ -2140,19 +2146,19 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
-  std::array<bool, BASE_KEY_NUM> h_accum_or_assigns_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
+  std::vector<uint8_t> h_accum_or_assigns_base(BASE_KEY_NUM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
-  std::array<bool, TEST_KEY_NUM> h_accum_or_assigns_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
+  std::vector<uint8_t> h_accum_or_assigns_test(TEST_KEY_NUM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -2165,7 +2171,7 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors,
       cudaMalloc(&d_vectors_temp, TEMP_KEY_NUM * sizeof(V) * options.dim));
   CUDA_CHECK(cudaMalloc(&d_accum_or_assigns_temp, TEMP_KEY_NUM * sizeof(bool)));
 
-  test_util::create_random_bools<K>(h_accum_or_assigns_base.data(),
+  test_util::create_random_bools<K>(reinterpret_cast<bool*>(h_accum_or_assigns_base.data()),
                                     BASE_KEY_NUM, base_true_ratio);
   test_util::create_keys_in_one_buckets<K, S, V, DIM>(
       h_keys_base.data(), h_scores_base.data(), h_vectors_base.data(),
@@ -2176,7 +2182,7 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors,
     h_scores_base[i] = base_score_start + i;
   }
 
-  test_util::create_random_bools<K>(h_accum_or_assigns_test.data(),
+  test_util::create_random_bools<K>(reinterpret_cast<bool*>(h_accum_or_assigns_test.data()),
                                     TEST_KEY_NUM, test_true_ratio);
   test_util::create_keys_in_one_buckets<K, S, V, DIM>(
       h_keys_test.data(), h_scores_test.data(), h_vectors_test.data(),
@@ -2244,7 +2250,7 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors,
                             cudaMemcpyHostToDevice));
       CUDA_CHECK(
           cudaMemcpy(d_accum_or_assigns_temp, h_accum_or_assigns_base.data(),
-                     BASE_KEY_NUM * sizeof(bool), cudaMemcpyHostToDevice));
+                     BASE_KEY_NUM * sizeof(uint8_t), cudaMemcpyHostToDevice));
       table->accum_or_assign(BASE_KEY_NUM, d_keys_temp, d_vectors_temp,
                              d_accum_or_assigns_temp, d_scores_temp, stream);
       CUDA_CHECK(cudaStreamSynchronize(stream));
@@ -2271,7 +2277,7 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors,
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
       for (int i = 0; i < dump_counter; i++) {

--- a/tests/assign_score_test.cc.cu
+++ b/tests/assign_score_test.cc.cu
@@ -46,7 +46,8 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -58,17 +59,17 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kLru>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -138,7 +139,7 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
       ASSERT_GE(h_scores_temp_sorted[0], start_ts);
@@ -184,7 +185,7 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
                             TEMP_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, TEST_KEY_NUM> h_scores_temp_sorted;
+      std::vector<S> h_scores_temp_sorted(TEST_KEY_NUM);
       int ctr = 0;
       for (int i = 0; i < TEMP_KEY_NUM; i++) {
         if (h_keys_test.end() !=
@@ -227,7 +228,8 @@ void test_evict_strategy_lfu_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -239,17 +241,17 @@ void test_evict_strategy_lfu_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kLfu>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -407,7 +409,8 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -419,17 +422,17 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kEpochLru>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -503,7 +506,7 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
       ASSERT_GE(h_scores_temp_sorted[0], (global_epoch << 32 | start_ts));
@@ -552,7 +555,7 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
                             TEMP_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, TEST_KEY_NUM> h_scores_temp_sorted;
+      std::vector<S> h_scores_temp_sorted(TEST_KEY_NUM);
       int ctr = 0;
       for (int i = 0; i < TEMP_KEY_NUM; i++) {
         if (h_keys_test.end() !=
@@ -595,7 +598,8 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -607,17 +611,17 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kEpochLfu>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -810,7 +814,8 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 128;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -822,17 +827,17 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -908,11 +913,11 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
-      ASSERT_TRUE((h_scores_temp_sorted ==
-                   test_util::range<S, TEMP_KEY_NUM>(base_score_start)));
+      auto expected_range = test_util::range<S, TEMP_KEY_NUM>(base_score_start);
+      ASSERT_TRUE(std::equal(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end(), expected_range.begin()));
       for (int i = 0; i < dump_counter; i++) {
         for (int j = 0; j < options.dim; j++) {
           ASSERT_EQ(h_vectors_temp[i * options.dim + j],
@@ -950,11 +955,11 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
                             TEMP_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, TEST_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
-      ASSERT_TRUE((h_scores_temp_sorted ==
-                   test_util::range<S, TEST_KEY_NUM>(test_score_start)));
+      auto expected_range_test = test_util::range<S, TEST_KEY_NUM>(test_score_start);
+      ASSERT_TRUE(std::equal(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end(), expected_range_test.begin()));
       for (int i = 0; i < dump_counter; i++) {
         for (int j = 0; j < options.dim; j++) {
           ASSERT_EQ(h_vectors_temp[i * options.dim + j],
@@ -982,7 +987,8 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 8;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 256;
 
   TableOptions options;
@@ -994,17 +1000,17 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -1094,11 +1100,11 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors,
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
-      ASSERT_TRUE((h_scores_temp_sorted ==
-                   test_util::range<S, TEMP_KEY_NUM>(base_score_start)));
+      auto expected_range = test_util::range<S, TEMP_KEY_NUM>(base_score_start);
+      ASSERT_TRUE(std::equal(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end(), expected_range.begin()));
       for (int i = 0; i < dump_counter; i++) {
         for (int j = 0; j < options.dim; j++) {
           ASSERT_EQ(h_vectors_temp[i * options.dim + j],

--- a/tests/assign_values_test.cc.cu
+++ b/tests/assign_values_test.cc.cu
@@ -45,7 +45,8 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -57,17 +58,17 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kLru>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -139,7 +140,7 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
       ASSERT_GE(h_scores_temp_sorted[0], start_ts);
@@ -212,7 +213,8 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -224,17 +226,17 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kEpochLfu>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;

--- a/tests/find_or_insert_ptr_lock_test.cc.cu
+++ b/tests/find_or_insert_ptr_lock_test.cc.cu
@@ -1172,7 +1172,8 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -1183,17 +1184,17 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kLru>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -1282,7 +1283,7 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
       ASSERT_GE(h_scores_temp_sorted[0], start_ts);
@@ -1344,7 +1345,7 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
                             TEMP_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, TEST_KEY_NUM> h_scores_temp_sorted;
+      std::vector<S> h_scores_temp_sorted(TEST_KEY_NUM);
       int ctr = 0;
       for (int i = 0; i < TEMP_KEY_NUM; i++) {
         if (h_keys_test.end() !=
@@ -1387,7 +1388,8 @@ void test_evict_strategy_lfu_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -1398,17 +1400,17 @@ void test_evict_strategy_lfu_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kLfu>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -1567,7 +1569,8 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -1578,17 +1581,17 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kEpochLru>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -1683,7 +1686,7 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
       ASSERT_GE(h_scores_temp_sorted[0], (global_epoch << 32 | start_ts));
@@ -1751,7 +1754,7 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
                             TEMP_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, TEST_KEY_NUM> h_scores_temp_sorted;
+      std::vector<S> h_scores_temp_sorted(TEST_KEY_NUM);
       int ctr = 0;
       for (int i = 0; i < TEMP_KEY_NUM; i++) {
         if (h_keys_test.end() !=
@@ -1794,7 +1797,8 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -1805,17 +1809,17 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kEpochLfu>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -2045,7 +2049,8 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 128;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -2056,17 +2061,17 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -2144,11 +2149,11 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
-      ASSERT_TRUE((h_scores_temp_sorted ==
-                   test_util::range<S, TEMP_KEY_NUM>(base_score_start)));
+      auto expected_range = test_util::range<S, TEMP_KEY_NUM>(base_score_start);
+      ASSERT_TRUE(std::equal(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end(), expected_range.begin()));
       for (int i = 0; i < dump_counter; i++) {
         for (int j = 0; j < options.dim; j++) {
           ASSERT_EQ(h_vectors_temp[i * options.dim + j],
@@ -2189,11 +2194,11 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
                             TEMP_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, TEST_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
-      ASSERT_TRUE((h_scores_temp_sorted ==
-                   test_util::range<S, TEST_KEY_NUM>(test_score_start)));
+      auto expected_range_test = test_util::range<S, TEST_KEY_NUM>(test_score_start);
+      ASSERT_TRUE(std::equal(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end(), expected_range_test.begin()));
       for (int i = 0; i < dump_counter; i++) {
         for (int j = 0; j < options.dim; j++) {
           ASSERT_EQ(h_vectors_temp[i * options.dim + j],
@@ -2221,7 +2226,8 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 8;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 256;
 
   TableOptions options;
@@ -2232,17 +2238,17 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -2334,11 +2340,11 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors,
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
-      ASSERT_TRUE((h_scores_temp_sorted ==
-                   test_util::range<S, TEMP_KEY_NUM>(base_score_start)));
+      auto expected_range = test_util::range<S, TEMP_KEY_NUM>(base_score_start);
+      ASSERT_TRUE(std::equal(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end(), expected_range.begin()));
       for (int i = 0; i < dump_counter; i++) {
         for (int j = 0; j < options.dim; j++) {
           ASSERT_EQ(h_vectors_temp[i * options.dim + j],

--- a/tests/find_or_insert_ptr_test.cc.cu
+++ b/tests/find_or_insert_ptr_test.cc.cu
@@ -1434,7 +1434,8 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -1445,17 +1446,17 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kLru>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -1540,7 +1541,7 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
       ASSERT_GE(h_scores_temp_sorted[0], start_ts);
@@ -1597,7 +1598,7 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
                             TEMP_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, TEST_KEY_NUM> h_scores_temp_sorted;
+      std::array<S, TEMP_KEY_NUM> h_scores_temp_sorted;
       int ctr = 0;
       for (int i = 0; i < TEMP_KEY_NUM; i++) {
         if (h_keys_test.end() !=
@@ -1640,7 +1641,8 @@ void test_evict_strategy_lfu_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -1651,17 +1653,17 @@ void test_evict_strategy_lfu_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kLfu>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -1839,7 +1841,8 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -1850,17 +1853,17 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kEpochLru>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -1949,7 +1952,7 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
       ASSERT_GE(h_scores_temp_sorted[0], (global_epoch << 32 | start_ts));
@@ -2011,22 +2014,24 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
                             TEMP_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, TEST_KEY_NUM> h_scores_temp_sorted;
-      int ctr = 0;
+      std::vector<S> h_scores_temp_sorted;
+      h_scores_temp_sorted.reserve(TEMP_KEY_NUM);
       for (int i = 0; i < TEMP_KEY_NUM; i++) {
         if (h_keys_test.end() !=
             std::find(h_keys_test.begin(), h_keys_test.end(), h_keys_temp[i])) {
           ASSERT_GE(h_scores_temp[i], (global_epoch << 32 | start_ts));
-          h_scores_temp_sorted[ctr++] = h_scores_temp[i];
+          h_scores_temp_sorted.push_back(h_scores_temp[i]);
         } else {
           ASSERT_LE(h_scores_temp[i], (global_epoch << 32 | start_ts));
         }
       }
       std::sort(h_scores_temp_sorted.begin(),
-                h_scores_temp_sorted.begin() + ctr);
+                h_scores_temp_sorted.end());
 
-      ASSERT_GE(h_scores_temp_sorted[0], (global_epoch << 32 | start_ts));
-      ASSERT_LE(h_scores_temp_sorted[ctr - 1], (global_epoch << 32 | end_ts));
+      if (!h_scores_temp_sorted.empty()) {
+        ASSERT_GE(h_scores_temp_sorted[0], (global_epoch << 32 | start_ts));
+        ASSERT_LE(h_scores_temp_sorted[h_scores_temp_sorted.size() - 1], (global_epoch << 32 | end_ts));
+      }
       for (int i = 0; i < dump_counter; i++) {
         for (int j = 0; j < options.dim; j++) {
           ASSERT_EQ(h_vectors_temp[i * options.dim + j],
@@ -2054,7 +2059,8 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -2065,17 +2071,17 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kEpochLfu>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -2293,7 +2299,8 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 128;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -2304,17 +2311,17 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -2402,11 +2409,11 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
-      ASSERT_TRUE((h_scores_temp_sorted ==
-                   test_util::range<S, TEMP_KEY_NUM>(base_score_start)));
+      auto expected_range = test_util::range<S, TEMP_KEY_NUM>(base_score_start);
+      ASSERT_TRUE(std::equal(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end(), expected_range.begin()));
       for (int i = 0; i < dump_counter; i++) {
         for (int j = 0; j < options.dim; j++) {
           ASSERT_EQ(h_vectors_temp[i * options.dim + j],
@@ -2457,11 +2464,11 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
                             TEMP_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, TEST_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
-      ASSERT_TRUE((h_scores_temp_sorted ==
-                   test_util::range<S, TEST_KEY_NUM>(test_score_start)));
+      auto expected_range_test = test_util::range<S, TEST_KEY_NUM>(test_score_start);
+      ASSERT_TRUE(std::equal(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end(), expected_range_test.begin()));
       for (int i = 0; i < dump_counter; i++) {
         for (int j = 0; j < options.dim; j++) {
           ASSERT_EQ(h_vectors_temp[i * options.dim + j],
@@ -2489,7 +2496,8 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 8;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 256;
 
   TableOptions options;
@@ -2500,17 +2508,17 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -2612,11 +2620,11 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors,
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
-      ASSERT_TRUE((h_scores_temp_sorted ==
-                   test_util::range<S, TEMP_KEY_NUM>(base_score_start)));
+      auto expected_range = test_util::range<S, TEMP_KEY_NUM>(base_score_start);
+      ASSERT_TRUE(std::equal(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end(), expected_range.begin()));
       for (int i = 0; i < dump_counter; i++) {
         for (int j = 0; j < options.dim; j++) {
           ASSERT_EQ(h_vectors_temp[i * options.dim + j],

--- a/tests/find_or_insert_test.cc.cu
+++ b/tests/find_or_insert_test.cc.cu
@@ -1298,7 +1298,8 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -1309,17 +1310,17 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kLru>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -1389,7 +1390,7 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
       ASSERT_GE(h_scores_temp_sorted[0], start_ts);
@@ -1433,7 +1434,7 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors,
                             TEMP_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, TEST_KEY_NUM> h_scores_temp_sorted;
+      std::array<S, TEMP_KEY_NUM> h_scores_temp_sorted;
       int ctr = 0;
       for (int i = 0; i < TEMP_KEY_NUM; i++) {
         if (h_keys_test.end() !=
@@ -1476,7 +1477,8 @@ void test_evict_strategy_lfu_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -1487,17 +1489,17 @@ void test_evict_strategy_lfu_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kLfu>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -1652,7 +1654,8 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -1663,17 +1666,17 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kEpochLru>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -1747,7 +1750,7 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
       ASSERT_GE(h_scores_temp_sorted[0], (global_epoch << 32 | start_ts));
@@ -1796,22 +1799,24 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors,
                             TEMP_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, TEST_KEY_NUM> h_scores_temp_sorted;
-      int ctr = 0;
+      std::vector<S> h_scores_temp_sorted;
+      h_scores_temp_sorted.reserve(TEMP_KEY_NUM);
       for (int i = 0; i < TEMP_KEY_NUM; i++) {
         if (h_keys_test.end() !=
             std::find(h_keys_test.begin(), h_keys_test.end(), h_keys_temp[i])) {
           ASSERT_GE(h_scores_temp[i], (global_epoch << 32 | start_ts));
-          h_scores_temp_sorted[ctr++] = h_scores_temp[i];
+          h_scores_temp_sorted.push_back(h_scores_temp[i]);
         } else {
           ASSERT_LE(h_scores_temp[i], (global_epoch << 32 | start_ts));
         }
       }
       std::sort(h_scores_temp_sorted.begin(),
-                h_scores_temp_sorted.begin() + ctr);
+                h_scores_temp_sorted.end());
 
-      ASSERT_GE(h_scores_temp_sorted[0], (global_epoch << 32 | start_ts));
-      ASSERT_LE(h_scores_temp_sorted[ctr - 1], (global_epoch << 32 | end_ts));
+      if (!h_scores_temp_sorted.empty()) {
+        ASSERT_GE(h_scores_temp_sorted[0], (global_epoch << 32 | start_ts));
+        ASSERT_LE(h_scores_temp_sorted[h_scores_temp_sorted.size() - 1], (global_epoch << 32 | end_ts));
+      }
       for (int i = 0; i < dump_counter; i++) {
         for (int j = 0; j < options.dim; j++) {
           ASSERT_EQ(h_vectors_temp[i * options.dim + j],
@@ -1839,7 +1844,8 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -1850,17 +1856,17 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kEpochLfu>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -2054,7 +2060,8 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 128;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -2065,17 +2072,17 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -2151,11 +2158,11 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
-      ASSERT_TRUE((h_scores_temp_sorted ==
-                   test_util::range<S, TEMP_KEY_NUM>(base_score_start)));
+      auto expected_range = test_util::range<S, TEMP_KEY_NUM>(base_score_start);
+      ASSERT_TRUE(std::equal(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end(), expected_range.begin()));
       for (int i = 0; i < dump_counter; i++) {
         for (int j = 0; j < options.dim; j++) {
           ASSERT_EQ(h_vectors_temp[i * options.dim + j],
@@ -2194,11 +2201,11 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors,
                             TEMP_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, TEST_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
-      ASSERT_TRUE((h_scores_temp_sorted ==
-                   test_util::range<S, TEST_KEY_NUM>(test_score_start)));
+      auto expected_range_test = test_util::range<S, TEST_KEY_NUM>(test_score_start);
+      ASSERT_TRUE(std::equal(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end(), expected_range_test.begin()));
       for (int i = 0; i < dump_counter; i++) {
         for (int j = 0; j < options.dim; j++) {
           ASSERT_EQ(h_vectors_temp[i * options.dim + j],
@@ -2226,7 +2233,8 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors,
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 8;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 256;
 
   TableOptions options;
@@ -2237,17 +2245,17 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors,
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -2337,11 +2345,11 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors,
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
-      ASSERT_TRUE((h_scores_temp_sorted ==
-                   test_util::range<S, TEMP_KEY_NUM>(base_score_start)));
+      auto expected_range = test_util::range<S, TEMP_KEY_NUM>(base_score_start);
+      ASSERT_TRUE(std::equal(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end(), expected_range.begin()));
       for (int i = 0; i < dump_counter; i++) {
         for (int j = 0; j < options.dim; j++) {
           ASSERT_EQ(h_vectors_temp[i * options.dim + j],

--- a/tests/merlin_hashtable_test.cc.cu
+++ b/tests/merlin_hashtable_test.cc.cu
@@ -106,8 +106,8 @@ struct ExportIfPredFunctor {
 
 class CustomizedAllocator : public virtual BaseAllocator {
  public:
-  CustomizedAllocator(){};
-  ~CustomizedAllocator() override{};
+  CustomizedAllocator() {};
+  ~CustomizedAllocator() override {};
 
   void alloc(const MemoryType type, void** ptr, size_t size,
              unsigned int pinned_flags = cudaHostAllocDefault) override {
@@ -1915,7 +1915,8 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors) {
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -1928,17 +1929,17 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors) {
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kLru>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -2008,7 +2009,7 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors) {
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
       ASSERT_GE(h_scores_temp_sorted[0], start_ts);
@@ -2051,7 +2052,7 @@ void test_evict_strategy_lru_basic(size_t max_hbm_for_vectors) {
                             TEMP_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, TEST_KEY_NUM> h_scores_temp_sorted;
+      std::array<S, TEMP_KEY_NUM> h_scores_temp_sorted;
       int ctr = 0;
       for (int i = 0; i < TEMP_KEY_NUM; i++) {
         if (h_keys_test.end() !=
@@ -2093,7 +2094,8 @@ void test_evict_strategy_lfu_basic(size_t max_hbm_for_vectors) {
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 1024;
 
   TableOptions options;
@@ -2106,17 +2108,17 @@ void test_evict_strategy_lfu_basic(size_t max_hbm_for_vectors) {
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kLfu>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -2272,7 +2274,8 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors) {
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -2285,17 +2288,17 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors) {
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kEpochLru>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -2369,7 +2372,7 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors) {
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
       ASSERT_GE(h_scores_temp_sorted[0], (global_epoch << 32 | start_ts));
@@ -2417,22 +2420,24 @@ void test_evict_strategy_epochlru_basic(size_t max_hbm_for_vectors) {
                             TEMP_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, TEST_KEY_NUM> h_scores_temp_sorted;
-      int ctr = 0;
+      std::vector<S> h_scores_temp_sorted;
+      h_scores_temp_sorted.reserve(TEMP_KEY_NUM);
       for (int i = 0; i < TEMP_KEY_NUM; i++) {
         if (h_keys_test.end() !=
             std::find(h_keys_test.begin(), h_keys_test.end(), h_keys_temp[i])) {
           ASSERT_GE(h_scores_temp[i], (global_epoch << 32 | start_ts));
-          h_scores_temp_sorted[ctr++] = h_scores_temp[i];
+          h_scores_temp_sorted.push_back(h_scores_temp[i]);
         } else {
           ASSERT_LE(h_scores_temp[i], (global_epoch << 32 | start_ts));
         }
       }
       std::sort(h_scores_temp_sorted.begin(),
-                h_scores_temp_sorted.begin() + ctr);
+                h_scores_temp_sorted.end());
 
-      ASSERT_GE(h_scores_temp_sorted[0], (global_epoch << 32 | start_ts));
-      ASSERT_LE(h_scores_temp_sorted[ctr - 1], (global_epoch << 32 | end_ts));
+      if (!h_scores_temp_sorted.empty()) {
+        ASSERT_GE(h_scores_temp_sorted[0], (global_epoch << 32 | start_ts));
+        ASSERT_LE(h_scores_temp_sorted[h_scores_temp_sorted.size() - 1], (global_epoch << 32 | end_ts));
+      }
       for (int i = 0; i < dump_counter; i++) {
         for (int j = 0; j < options.dim; j++) {
           ASSERT_EQ(h_vectors_temp[i * options.dim + j],
@@ -2459,7 +2464,8 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors) {
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 4;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -2472,17 +2478,17 @@ void test_evict_strategy_epochlfu_basic(size_t max_hbm_for_vectors) {
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kEpochLfu>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -2672,7 +2678,8 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors) {
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 128;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 128;
 
   TableOptions options;
@@ -2685,17 +2692,17 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors) {
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -2771,11 +2778,11 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors) {
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
-      ASSERT_TRUE((h_scores_temp_sorted ==
-                   test_util::range<S, TEMP_KEY_NUM>(base_score_start)));
+      auto expected_range = test_util::range<S, TEMP_KEY_NUM>(base_score_start);
+      ASSERT_TRUE(std::equal(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end(), expected_range.begin()));
       for (int i = 0; i < dump_counter; i++) {
         for (int j = 0; j < options.dim; j++) {
           ASSERT_EQ(h_vectors_temp[i * options.dim + j],
@@ -2812,11 +2819,11 @@ void test_evict_strategy_customized_basic(size_t max_hbm_for_vectors) {
                             TEMP_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, TEST_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
-      ASSERT_TRUE((h_scores_temp_sorted ==
-                   test_util::range<S, TEST_KEY_NUM>(test_score_start)));
+      auto expected_range_test = test_util::range<S, TEST_KEY_NUM>(test_score_start);
+      ASSERT_TRUE(std::equal(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end(), expected_range_test.begin()));
       for (int i = 0; i < dump_counter; i++) {
         for (int j = 0; j < options.dim; j++) {
           ASSERT_EQ(h_vectors_temp[i * options.dim + j],
@@ -2843,7 +2850,8 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors) {
   constexpr uint64_t MAX_CAPACITY = INIT_CAPACITY;
   constexpr uint64_t BASE_KEY_NUM = BUCKET_MAX_SIZE;
   constexpr uint64_t TEST_KEY_NUM = 8;
-  constexpr uint64_t TEMP_KEY_NUM = std::max(BASE_KEY_NUM, TEST_KEY_NUM);
+  constexpr uint64_t TEMP_KEY_NUM =
+      (BASE_KEY_NUM > TEST_KEY_NUM) ? BASE_KEY_NUM : TEST_KEY_NUM;
   constexpr uint64_t TEST_TIMES = 256;
 
   TableOptions options;
@@ -2856,17 +2864,17 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors) {
   options.max_hbm_for_vectors = nv::merlin::GB(max_hbm_for_vectors);
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
 
-  std::array<K, BASE_KEY_NUM> h_keys_base;
-  std::array<S, BASE_KEY_NUM> h_scores_base;
-  std::array<V, BASE_KEY_NUM * DIM> h_vectors_base;
+  std::vector<K> h_keys_base(BASE_KEY_NUM);
+  std::vector<S> h_scores_base(BASE_KEY_NUM);
+  std::vector<V> h_vectors_base(BASE_KEY_NUM * DIM);
 
-  std::array<K, TEST_KEY_NUM> h_keys_test;
-  std::array<S, TEST_KEY_NUM> h_scores_test;
-  std::array<V, TEST_KEY_NUM * DIM> h_vectors_test;
+  std::vector<K> h_keys_test(TEST_KEY_NUM);
+  std::vector<S> h_scores_test(TEST_KEY_NUM);
+  std::vector<V> h_vectors_test(TEST_KEY_NUM * DIM);
 
-  std::array<K, TEMP_KEY_NUM> h_keys_temp;
-  std::array<S, TEMP_KEY_NUM> h_scores_temp;
-  std::array<V, TEMP_KEY_NUM * DIM> h_vectors_temp;
+  std::vector<K> h_keys_temp(TEMP_KEY_NUM);
+  std::vector<S> h_scores_temp(TEMP_KEY_NUM);
+  std::vector<V> h_vectors_temp(TEMP_KEY_NUM * DIM);
 
   K* d_keys_temp;
   S* d_scores_temp = nullptr;
@@ -2957,11 +2965,11 @@ void test_evict_strategy_customized_advanced(size_t max_hbm_for_vectors) {
                             BASE_KEY_NUM * sizeof(V) * options.dim,
                             cudaMemcpyDefault));
 
-      std::array<S, BASE_KEY_NUM> h_scores_temp_sorted(h_scores_temp);
+      std::vector<S> h_scores_temp_sorted(h_scores_temp);
       std::sort(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end());
 
-      ASSERT_TRUE((h_scores_temp_sorted ==
-                   test_util::range<S, TEMP_KEY_NUM>(base_score_start)));
+      auto expected_range = test_util::range<S, TEMP_KEY_NUM>(base_score_start);
+      ASSERT_TRUE(std::equal(h_scores_temp_sorted.begin(), h_scores_temp_sorted.end(), expected_range.begin()));
       for (int i = 0; i < dump_counter; i++) {
         for (int j = 0; j < options.dim; j++) {
           ASSERT_EQ(h_vectors_temp[i * options.dim + j],


### PR DESCRIPTION
- Try to fix the compilation errors with CUDA 12.x, like:

```shell
/HierarchicalKV/tests/merlin_hashtable_test.cc.cu:2423:162: error: template argument 2 is invalid
 2423 |       std::array<S, TEMP_KEY_NUM> h_scores_temp_sorted;                                     
```
This issue is likely caused by the stricter conditional `constexpr` checks in the new NVCC.

- Todo:

Replacing the `cub::Sum` with `cuda::std::plus`, which can be time-consuming for changing more core files, and need to verify the impact on perf.

The possibly impacted files list:

```shell
include/merlin/core_kernels/*.cuh
include/merlin/*.cuh
include/merlin_hashtable.cuh
```
 
```shell
In file included from tmpxft_00000c1b_00000000-6_find_or_insert_ptr_test.cc.cudafe1.stub.c:1:
/tmp/tmpxft_00000c1b_00000000-6_find_or_insert_ptr_test.cc.cudafe1.stub.c:6289:345: warning: ‘using cub::CUB_200802_SM_860::Sum = struct cuda::std::__4::plus<>’ is deprecated: use cuda::std::plus instead [-Wdeprecated-declarations]
 6289 | 
```