### PR TITLE
[Fix] Correct RECLAIM_KEY digest in remove_kernel

### DIFF
--- a/include/merlin/core_kernels.cuh
+++ b/include/merlin/core_kernels.cuh
@@ -758,7 +758,7 @@ __global__ void remove_kernel(const Table<K, V, S>* __restrict table,
         if (pred(current_key, current_score, pattern, threshold)) {
           atomicAdd(count, 1);
           key_pos = key_offset;
-          bucket->digests(key_pos)[0] = empty_digest<K>();
+          bucket->digests(key_pos)[0] = reclaim_digest<K>();
           (bucket->keys(key_pos))
               ->store(static_cast<K>(RECLAIM_KEY),
                       cuda::std::memory_order_relaxed);
@@ -815,7 +815,7 @@ __global__ void remove_kernel_v2(const uint64_t search_length,
     }
     // Only matched threads need to erase.
     if (match) {
-      bucket->digests(key_idx)[0] = empty_digest<K>();
+      bucket->digests(key_idx)[0] = reclaim_digest<K>();
       bucket->keys(key_idx)->store(static_cast<K>(RECLAIM_KEY),
                                    cuda::std::memory_order_relaxed);
       bucket->scores(key_idx)->store(static_cast<S>(EMPTY_SCORE),


### PR DESCRIPTION
**Description:** This PR fixes a performance issue in remove_kernel and remove_kernel_v2 where the digest for a RECLAIM_KEY was incorrectly set to empty_digest<K>().

**Issue:** When a key is removed and marked as RECLAIM_KEY, setting its digest to empty_digest causes the probing logic to falsely identify the slot as a potential candidate for an empty key. This triggers unnecessary memory accesses (loading the Key) to confirm the slot status, only to discover it is actually a RECLAIM_KEY and continue probing.

**Fix:** Updated the code to set the digest to reclaim_digest<K>() instead of empty_digest. This allows the SIMD filter to correctly distinguish between true Empty slots and Reclaimed slots, avoiding redundant Key loads and improving probing efficiency.