### PR TITLE
[Feat] Add the support of Dual buckets - 1st phase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,12 @@ cmake_minimum_required(VERSION 3.10)
 project(merlin-hkvs LANGUAGES CXX CUDA)
 find_package(CUDAToolkit)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CUDA_STANDARD 14)
+# TODO(Q3): target_compile_features below still declare cxx_std_14, which is
+# inconsistent with the project-level C++17.  Update them to cxx_std_17 (or
+# remove the per-target lines entirely) once downstream compatibility is
+# confirmed.
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CUDA_STANDARD 17)
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 
 option(CLANGFORMAT "Clangformat code files before compiling" OFF)
@@ -178,3 +182,12 @@ add_executable(lock_unlock_test tests/lock_unlock_test.cc.cu)
 target_compile_features(lock_unlock_test PUBLIC cxx_std_14)
 set_target_properties(lock_unlock_test PROPERTIES  CUDA_ARCHITECTURES OFF)
 TARGET_LINK_LIBRARIES(lock_unlock_test gtest_main)
+
+add_executable(dual_bucket_test tests/dual_bucket_test.cc.cu)
+target_compile_features(dual_bucket_test PUBLIC cxx_std_14)
+set_target_properties(dual_bucket_test PROPERTIES  CUDA_ARCHITECTURES OFF)
+TARGET_LINK_LIBRARIES(dual_bucket_test gtest_main)
+
+add_executable(dual_bucket_benchmark benchmark/dual_bucket_benchmark.cc.cu)
+target_compile_features(dual_bucket_benchmark PUBLIC cxx_std_14)
+set_target_properties(dual_bucket_benchmark PROPERTIES  CUDA_ARCHITECTURES OFF)

--- a/benchmark/dual_bucket_benchmark.cc.cu
+++ b/benchmark/dual_bucket_benchmark.cc.cu
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <chrono>
+#include <cstdio>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <vector>
+#include "merlin_hashtable.cuh"
+
+using K = uint64_t;
+using V = float;
+using S = uint64_t;
+using TableOptions = nv::merlin::HashTableOptions;
+using TableMode = nv::merlin::TableMode;
+using EvictStrategy = nv::merlin::EvictStrategy;
+
+template <typename Table>
+double benchmark_insert(Table& table, size_t n, K* d_keys, V* d_values,
+                        S* d_scores, cudaStream_t stream) {
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  auto start = std::chrono::high_resolution_clock::now();
+  table.insert_or_assign(n, d_keys, d_values, d_scores, stream, true);
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  auto end = std::chrono::high_resolution_clock::now();
+  double ms = std::chrono::duration_cast<std::chrono::microseconds>(end - start)
+                  .count() /
+              1000.0;
+  return static_cast<double>(n) / ms / 1000.0;  // Mops/s
+}
+
+template <typename Table>
+double benchmark_find(Table& table, size_t n, K* d_keys, V* d_values,
+                      bool* d_founds, cudaStream_t stream) {
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  auto start = std::chrono::high_resolution_clock::now();
+  table.find(n, d_keys, d_values, d_founds, nullptr, stream);
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  auto end = std::chrono::high_resolution_clock::now();
+  double ms = std::chrono::duration_cast<std::chrono::microseconds>(end - start)
+                  .count() /
+              1000.0;
+  return static_cast<double>(n) / ms / 1000.0;  // Mops/s
+}
+
+void run_benchmark(size_t capacity, size_t dim, TableMode mode,
+                   const char* mode_name) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+  Table table;
+  TableOptions options;
+  options.init_capacity = capacity;
+  options.max_capacity = capacity;
+  options.max_hbm_for_vectors = 0;
+  options.dim = dim;
+  options.max_bucket_size = 128;
+  options.table_mode = mode;
+  table.init(options);
+
+  cudaStream_t stream;
+  CUDA_CHECK(cudaStreamCreate(&stream));
+
+  // Generate keys.
+  size_t max_n = capacity;
+  std::vector<K> h_keys(max_n);
+  std::vector<V> h_values(max_n * dim, 1.0f);
+  std::vector<S> h_scores(max_n);
+  std::iota(h_keys.begin(), h_keys.end(), 1);
+  for (size_t i = 0; i < max_n; i++) h_scores[i] = i + 1;
+
+  K* d_keys;
+  V* d_values;
+  S* d_scores;
+  bool* d_founds;
+  V* d_found_values;
+  CUDA_CHECK(cudaMalloc(&d_keys, max_n * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, max_n * dim * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_scores, max_n * sizeof(S)));
+  CUDA_CHECK(cudaMalloc(&d_founds, max_n * sizeof(bool)));
+  CUDA_CHECK(cudaMalloc(&d_found_values, max_n * dim * sizeof(V)));
+
+  CUDA_CHECK(cudaMemcpy(d_keys, h_keys.data(), max_n * sizeof(K),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_values, h_values.data(), max_n * dim * sizeof(V),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_scores, h_scores.data(), max_n * sizeof(S),
+                        cudaMemcpyHostToDevice));
+
+  printf("--- %s (capacity=%zuK, dim=%zu) ---\n", mode_name, capacity / 1024,
+         dim);
+  printf("  %-12s  %-18s  %-18s\n", "Load Factor", "Insert (Mops/s)",
+         "Find (Mops/s)");
+
+  float load_factors[] = {0.25f, 0.50f, 0.75f, 0.90f, 0.95f, 1.00f};
+  size_t prev_n = 0;
+
+  for (float lf : load_factors) {
+    size_t target_n = static_cast<size_t>(capacity * lf);
+    if (target_n > max_n) break;
+    size_t batch_n = target_n - prev_n;
+    if (batch_n == 0) continue;
+
+    // Insert to reach target load factor.
+    double insert_mops =
+        benchmark_insert(table, batch_n, d_keys + prev_n,
+                         d_values + prev_n * dim, d_scores + prev_n, stream);
+
+    // Find all inserted keys.
+    double find_mops = benchmark_find(table, target_n, d_keys, d_found_values,
+                                      d_founds, stream);
+
+    printf("  %-12.2f  %-18.1f  %-18.1f\n", lf, insert_mops, find_mops);
+    prev_n = target_n;
+  }
+
+  // Memory efficiency: first eviction LF.
+  // (Already covered in test, report here too.)
+  size_t table_size = table.size(stream);
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  printf("  Final size: %zu / %zu (LF=%.4f)\n", table_size, capacity,
+         static_cast<float>(table_size) / capacity);
+
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+  CUDA_CHECK(cudaFree(d_scores));
+  CUDA_CHECK(cudaFree(d_founds));
+  CUDA_CHECK(cudaFree(d_found_values));
+  CUDA_CHECK(cudaStreamDestroy(stream));
+}
+
+int main(int argc, char** argv) {
+  printf("=== Dual-Bucket Benchmark Results ===\n\n");
+
+  // Default: 1M capacity, dim=64.
+  size_t capacity = 128 * 1024 * 8;  // ~1M
+  size_t dim = 64;
+
+  if (argc > 1) capacity = static_cast<size_t>(atol(argv[1]));
+  if (argc > 2) dim = static_cast<size_t>(atol(argv[2]));
+
+  run_benchmark(capacity, dim, TableMode::kThroughput, "THROUGHPUT_MODE");
+  printf("\n");
+  run_benchmark(capacity, dim, TableMode::kMemory, "MEMORY_MODE");
+  printf("\n");
+
+  printf("=== Benchmark Complete ===\n");
+  return 0;
+}

--- a/include/merlin/core_kernels/dual_bucket_lookup.cuh
+++ b/include/merlin/core_kernels/dual_bucket_lookup.cuh
@@ -1,0 +1,743 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "dual_bucket_utils.cuh"
+#include "kernel_utils.cuh"
+
+namespace nv {
+namespace merlin {
+
+/**
+ * Dual-bucket pipeline lookup kernel (sequential two-bucket search).
+ *
+ * For each key, computes (b1, b2) via high/low 32-bit split of Murmur3 hash.
+ * First probes b1; if not found, probes b2.
+ * Uses dual_bucket_digest (bit[56:63]) to avoid digest collision with b2
+ * addressing.
+ *
+ * Architecture: Based on lookup_kernel_with_io_pipeline_v1 with 32 threads
+ * per key, 128-thread blocks, 128-slot buckets. 4-stage IO pipeline
+ * (prefetch digests -> digest match + key load -> key verify + value prefetch
+ * -> value writeback).
+ */
+template <class K, class V, class S, class VecV,
+          typename CopyScore = CopyScoreEmpty<S, K, 128>,
+          typename CopyValue = CopyValueTwoGroup<VecV, 32>,
+          typename FoundFunctor = FoundFunctorV1<K>, int VALUE_BUF = 56>
+__global__ void dual_bucket_pipeline_lookup_kernel_with_io(
+    Bucket<K, V, S>* buckets, const int32_t* __restrict__ buckets_size,
+    const size_t buckets_num, const int dim, const K* __restrict keys,
+    VecV* __restrict values, S* __restrict scores, FoundFunctor found_functor,
+    size_t n) {
+  constexpr int GROUP_SIZE = 32;
+  constexpr int RESERVE = 16;
+  constexpr int BLOCK_SIZE = 128;
+  constexpr int BUCKET_SIZE = 128;
+  constexpr int GROUP_NUM = BLOCK_SIZE / GROUP_SIZE;
+  constexpr int DIGEST_SPAN = BUCKET_SIZE / 4;
+
+  using BUCKET = Bucket<K, V, S>;
+
+  // Shared memory declarations.
+  __shared__ int sm_target_digests[BLOCK_SIZE];
+  __shared__ K sm_target_keys[BLOCK_SIZE];
+  __shared__ K* sm_keys_ptr1[BLOCK_SIZE];       // b1 bucket keys ptr
+  __shared__ K* sm_keys_ptr2[BLOCK_SIZE];       // b2 bucket keys ptr
+  __shared__ VecV* sm_values_ptr1[BLOCK_SIZE];  // b1 values ptr
+  __shared__ VecV* sm_values_ptr2[BLOCK_SIZE];  // b2 values ptr
+  __shared__ S sm_target_scores[BLOCK_SIZE];
+  // Reuse sm_target_digests
+  int* sm_counts = sm_target_digests;
+  int* sm_founds = sm_counts;
+  // Double buffer
+  __shared__ uint32_t sm_probing_digests[2][GROUP_NUM * DIGEST_SPAN];
+  __shared__ K sm_possible_keys[2][GROUP_NUM * RESERVE];
+  __shared__ int sm_possible_pos[2][GROUP_NUM * RESERVE];
+  __shared__ VecV sm_vector[2][GROUP_NUM][VALUE_BUF];
+
+  // Initialization.
+  auto g = cg::tiled_partition<GROUP_SIZE>(cg::this_thread_block());
+  int groupID = threadIdx.x / GROUP_SIZE;
+  int rank = g.thread_rank();
+  int key_idx_base = (blockIdx.x * blockDim.x) + groupID * GROUP_SIZE;
+  if (key_idx_base >= n) return;
+  int loop_num =
+      (n - key_idx_base) < GROUP_SIZE ? (n - key_idx_base) : GROUP_SIZE;
+
+  // Phase 1: Initialize per-key data (hash, digest, bucket pointers).
+  // Save digest in register to avoid recomputing Murmur3 hash in Pass 2
+  // (sm_target_digests is aliased with sm_counts/sm_founds and gets
+  // corrupted during Pass 1).
+  uint32_t reg_target_digest = 0;
+  if (rank < loop_num) {
+    int idx_block = groupID * GROUP_SIZE + rank;
+    K target_key = keys[key_idx_base + rank];
+    sm_target_keys[idx_block] = target_key;
+    const K hashed_key = Murmur3HashDevice(target_key);
+
+    // Dual-bucket digest: bit[56:63]
+    const uint8_t target_digest =
+        static_cast<uint8_t>(static_cast<uint64_t>(hashed_key) >> 56);
+    reg_target_digest = static_cast<uint32_t>(target_digest);
+    sm_target_digests[idx_block] = reg_target_digest;
+
+    // Dual-bucket positions (centralized in dual_bucket_utils.cuh).
+    size_t bkt_idx1, bkt_idx2;
+    get_dual_bucket_indices<K>(hashed_key, buckets_num, bkt_idx1, bkt_idx2);
+
+    BUCKET* bucket1 = buckets + bkt_idx1;
+    BUCKET* bucket2 = buckets + bkt_idx2;
+    sm_keys_ptr1[idx_block] = reinterpret_cast<K*>(bucket1->keys(0));
+    sm_keys_ptr2[idx_block] = reinterpret_cast<K*>(bucket2->keys(0));
+    __pipeline_memcpy_async(sm_values_ptr1 + idx_block, &(bucket1->vectors),
+                            sizeof(VecV*));
+    __pipeline_commit();
+    __pipeline_memcpy_async(sm_values_ptr2 + idx_block, &(bucket2->vectors),
+                            sizeof(VecV*));
+  }
+  __pipeline_wait_prior(0);
+
+  // Helper lambda-like function to run pipeline lookup on one bucket.
+  // We process keys sequentially through the pipeline for one bucket,
+  // then process missed keys through the second bucket.
+
+  // --- PASS 1: Search bucket b1 ---
+  // Pipeline loading for b1.
+  {
+    uint8_t* digests_ptr =
+        reinterpret_cast<uint8_t*>(sm_keys_ptr1[groupID * GROUP_SIZE]) -
+        BUCKET_SIZE;
+    __pipeline_memcpy_async(
+        sm_probing_digests[0] + groupID * DIGEST_SPAN + rank,
+        digests_ptr + rank * 4, sizeof(uint32_t));
+  }
+  __pipeline_commit();
+  __pipeline_commit();
+  __pipeline_commit();
+
+  for (int i = 0; i < loop_num; i++) {
+    int key_idx_block = groupID * GROUP_SIZE + i;
+
+    // Step1: prefetch digests for next key's b1 bucket.
+    if ((i + 1) < loop_num) {
+      uint8_t* digests_ptr =
+          reinterpret_cast<uint8_t*>(sm_keys_ptr1[key_idx_block + 1]) -
+          BUCKET_SIZE;
+      __pipeline_memcpy_async(
+          sm_probing_digests[diff_buf(i)] + groupID * DIGEST_SPAN + rank,
+          digests_ptr + rank * 4, sizeof(uint32_t));
+    }
+    __pipeline_commit();
+
+    // Step2: check digests and load possible keys.
+    uint32_t target_digest = sm_target_digests[key_idx_block];
+    uint32_t target_digests_vec =
+        __byte_perm(target_digest, target_digest, 0x0000);
+    sm_counts[key_idx_block] = 0;
+    __pipeline_wait_prior(3);
+    uint32_t probing_digests =
+        sm_probing_digests[same_buf(i)][groupID * DIGEST_SPAN + rank];
+    uint32_t find_result_ = __vcmpeq4(probing_digests, target_digests_vec);
+    uint32_t find_result = 0;
+    if ((find_result_ & 0x01) != 0) find_result |= 0x01;
+    if ((find_result_ & 0x0100) != 0) find_result |= 0x02;
+    if ((find_result_ & 0x010000) != 0) find_result |= 0x04;
+    if ((find_result_ & 0x01000000) != 0) find_result |= 0x08;
+    int find_number = __popc(find_result);
+    int group_base = 0;
+    if (find_number > 0) {
+      group_base = atomicAdd(sm_counts + key_idx_block, find_number);
+    }
+    bool gt_reserve = (group_base + find_number) > RESERVE;
+    int gt_vote = g.ballot(gt_reserve);
+    K* key_ptr = sm_keys_ptr1[key_idx_block];
+    if (gt_vote == 0) {
+      do {
+        int digest_idx = __ffs(find_result) - 1;
+        if (digest_idx >= 0) {
+          find_result &= (find_result - 1);
+          int key_pos = rank * 4 + digest_idx;
+          sm_possible_pos[same_buf(i)][groupID * RESERVE + group_base] =
+              key_pos;
+          __pipeline_memcpy_async(
+              sm_possible_keys[same_buf(i)] + (groupID * RESERVE + group_base),
+              key_ptr + key_pos, sizeof(K));
+          group_base += 1;
+        } else {
+          break;
+        }
+      } while (true);
+    } else {
+      K target_key = sm_target_keys[key_idx_block];
+      sm_counts[key_idx_block] = 0;
+      int found_vote = 0;
+      bool found = false;
+      do {
+        int digest_idx = __ffs(find_result) - 1;
+        if (digest_idx >= 0) {
+          find_result &= (find_result - 1);
+          int key_pos = rank * 4 + digest_idx;
+          K possible_key = key_ptr[key_pos];
+          if (possible_key == target_key) {
+            found = true;
+            sm_counts[key_idx_block] = 1;
+            sm_possible_pos[same_buf(i)][groupID * RESERVE] = key_pos;
+            sm_possible_keys[same_buf(i)][groupID * RESERVE] = possible_key;
+          }
+        }
+        found_vote = g.ballot(found);
+        if (found_vote) break;
+        found_vote = digest_idx >= 0;
+      } while (g.any(found_vote));
+    }
+    __pipeline_commit();
+
+    // Step3: verify keys, prefetch values.
+    if (i > 0) {
+      int prev_block = groupID * GROUP_SIZE + i - 1;
+      K target_key = sm_target_keys[prev_block];
+      int possible_num = sm_counts[prev_block];
+      sm_founds[prev_block] = 0;
+      S* score_ptr = CopyScore::get_base_ptr(sm_keys_ptr1, prev_block);
+      VecV* value_ptr = sm_values_ptr1[prev_block];
+      __pipeline_wait_prior(3);
+      int key_pos;
+      bool found_flag = false;
+      if (rank < possible_num) {
+        K possible_key =
+            sm_possible_keys[diff_buf(i)][groupID * RESERVE + rank];
+        key_pos = sm_possible_pos[diff_buf(i)][groupID * RESERVE + rank];
+        if (possible_key == target_key) {
+          found_flag = true;
+          CopyScore::ldg_sts(sm_target_scores + prev_block,
+                             score_ptr + key_pos);
+        }
+      }
+      int found_vote = g.ballot(found_flag);
+      if (found_vote) {
+        VecV* v_dst = sm_vector[diff_buf(i)][groupID];
+        sm_founds[prev_block] = 1;
+        int src_lane = __ffs(found_vote) - 1;
+        int target_pos = g.shfl(key_pos, src_lane);
+        VecV* v_src = value_ptr + target_pos * dim;
+        CopyValue::ldg_sts(rank, v_dst, v_src, dim);
+      }
+    }
+    __pipeline_commit();
+
+    // Step4: write back value and score.
+    if (i > 1) {
+      int wb_block = groupID * GROUP_SIZE + i - 2;
+      int key_idx_grid = blockIdx.x * blockDim.x + wb_block;
+      VecV* v_src = sm_vector[same_buf(i)][groupID];
+      VecV* v_dst = values + key_idx_grid * dim;
+      int found_flag = sm_founds[wb_block];
+      __pipeline_wait_prior(3);
+      if (found_flag > 0) {
+        S score_ = CopyScore::lgs(sm_target_scores + wb_block);
+        CopyValue::lds_stg(rank, v_dst, v_src, dim);
+        CopyScore::stg(scores + key_idx_grid, score_);
+      }
+    }
+  }
+
+  // Pipeline emptying for b1: step3 for last key.
+  {
+    int key_idx_block = groupID * GROUP_SIZE + (loop_num - 1);
+    K target_key = sm_target_keys[key_idx_block];
+    int possible_num = sm_counts[key_idx_block];
+    sm_founds[key_idx_block] = 0;
+    S* score_ptr = CopyScore::get_base_ptr(sm_keys_ptr1, key_idx_block);
+    VecV* value_ptr = sm_values_ptr1[key_idx_block];
+    __pipeline_wait_prior(1);
+    int key_pos;
+    bool found_flag = false;
+    if (rank < possible_num) {
+      key_pos = sm_possible_pos[diff_buf(loop_num)][groupID * RESERVE + rank];
+      K possible_key =
+          sm_possible_keys[diff_buf(loop_num)][groupID * RESERVE + rank];
+      if (target_key == possible_key) {
+        found_flag = true;
+        CopyScore::ldg_sts(sm_target_scores + key_idx_block,
+                           score_ptr + key_pos);
+      }
+    }
+    int found_vote = g.ballot(found_flag);
+    if (found_vote) {
+      sm_founds[key_idx_block] = 1;
+      int src_lane = __ffs(found_vote) - 1;
+      int target_pos = g.shfl(key_pos, src_lane);
+      VecV* v_src = value_ptr + target_pos * dim;
+      VecV* v_dst = sm_vector[diff_buf(loop_num)][groupID];
+      CopyValue::ldg_sts(rank, v_dst, v_src, dim);
+    }
+  }
+  __pipeline_commit();
+
+  // Pipeline emptying: step4 for second-to-last key.
+  if (loop_num > 1) {
+    int key_idx_block = groupID * GROUP_SIZE + loop_num - 2;
+    int key_idx_grid = blockIdx.x * blockDim.x + key_idx_block;
+    VecV* v_src = sm_vector[same_buf(loop_num)][groupID];
+    VecV* v_dst = values + key_idx_grid * dim;
+    int found_flag = sm_founds[key_idx_block];
+    __pipeline_wait_prior(1);
+    if (found_flag > 0) {
+      S score_ = CopyScore::lgs(sm_target_scores + key_idx_block);
+      CopyValue::lds_stg(rank, v_dst, v_src, dim);
+      CopyScore::stg(scores + key_idx_grid, score_);
+    }
+  }
+
+  // Pipeline emptying: step4 for last key.
+  {
+    int key_idx_block = groupID * GROUP_SIZE + loop_num - 1;
+    int key_idx_grid = blockIdx.x * blockDim.x + key_idx_block;
+    VecV* v_src = sm_vector[same_buf(loop_num + 1)][groupID];
+    VecV* v_dst = values + key_idx_grid * dim;
+    int found_flag = sm_founds[key_idx_block];
+    __pipeline_wait_prior(0);
+    if (found_flag > 0) {
+      S score_ = CopyScore::lgs(sm_target_scores + key_idx_block);
+      CopyValue::lds_stg(rank, v_dst, v_src, dim);
+      CopyScore::stg(scores + key_idx_grid, score_);
+    }
+  }
+
+  // Finalize b1 pass and record found status.
+  // Keys found in b1 are marked. Unfound keys need b2 search.
+  if (rank < loop_num) {
+    int key_idx_block = groupID * GROUP_SIZE + rank;
+    int key_idx_grid = blockIdx.x * blockDim.x + key_idx_block;
+    // Only write found for b1 hits; b2 pass will handle misses.
+    if (sm_founds[key_idx_block] > 0) {
+      found_functor(key_idx_grid, sm_target_keys[key_idx_block], true);
+    }
+  }
+
+  // --- PASS 2: Search bucket b2 for keys not found in b1 ---
+  // Count unfound keys. If all found in b1, skip b2 entirely.
+  int any_unfound = 0;
+  if (rank < loop_num) {
+    int key_idx_block = groupID * GROUP_SIZE + rank;
+    if (sm_founds[key_idx_block] == 0) {
+      any_unfound = 1;
+    }
+  }
+  any_unfound = g.any(any_unfound);
+  if (!any_unfound) return;
+
+  // Save b1 found flags (sm_founds will be reused).
+  // We use a simple approach: store per-thread found flag in register.
+  int b1_found = 0;
+  if (rank < loop_num) {
+    b1_found = sm_founds[groupID * GROUP_SIZE + rank];
+  }
+
+  // Restore digests from registers saved during Phase 1 init.
+  // sm_target_digests was aliased with sm_counts/sm_founds and corrupted
+  // during Pass 1.  Using the register avoids recomputing Murmur3 hash.
+  if (rank < loop_num) {
+    int idx_block = groupID * GROUP_SIZE + rank;
+    sm_target_digests[idx_block] = reg_target_digest;
+  }
+  __syncwarp();
+
+  // Pipeline loading for b2.
+  {
+    uint8_t* digests_ptr =
+        reinterpret_cast<uint8_t*>(sm_keys_ptr2[groupID * GROUP_SIZE]) -
+        BUCKET_SIZE;
+    __pipeline_memcpy_async(
+        sm_probing_digests[0] + groupID * DIGEST_SPAN + rank,
+        digests_ptr + rank * 4, sizeof(uint32_t));
+  }
+  __pipeline_commit();
+  __pipeline_commit();
+  __pipeline_commit();
+
+  for (int i = 0; i < loop_num; i++) {
+    int key_idx_block = groupID * GROUP_SIZE + i;
+    // Check if this key was already found in b1.
+    int skip = g.shfl(b1_found, i);
+
+    // Step1: prefetch digests for next key's b2 bucket.
+    if ((i + 1) < loop_num) {
+      uint8_t* digests_ptr =
+          reinterpret_cast<uint8_t*>(sm_keys_ptr2[key_idx_block + 1]) -
+          BUCKET_SIZE;
+      __pipeline_memcpy_async(
+          sm_probing_digests[diff_buf(i)] + groupID * DIGEST_SPAN + rank,
+          digests_ptr + rank * 4, sizeof(uint32_t));
+    }
+    __pipeline_commit();
+
+    // Step2: check digests and load possible keys (skip if found in b1).
+    // Read digest BEFORE zeroing sm_counts (they alias sm_target_digests).
+    uint32_t target_digest = sm_target_digests[key_idx_block];
+    sm_counts[key_idx_block] = 0;
+    if (!skip) {
+      uint32_t target_digests_vec =
+          __byte_perm(target_digest, target_digest, 0x0000);
+      __pipeline_wait_prior(3);
+      uint32_t probing_digests =
+          sm_probing_digests[same_buf(i)][groupID * DIGEST_SPAN + rank];
+      uint32_t find_result_ = __vcmpeq4(probing_digests, target_digests_vec);
+      uint32_t find_result = 0;
+      if ((find_result_ & 0x01) != 0) find_result |= 0x01;
+      if ((find_result_ & 0x0100) != 0) find_result |= 0x02;
+      if ((find_result_ & 0x010000) != 0) find_result |= 0x04;
+      if ((find_result_ & 0x01000000) != 0) find_result |= 0x08;
+      int find_number = __popc(find_result);
+      int group_base = 0;
+      if (find_number > 0) {
+        group_base = atomicAdd(sm_counts + key_idx_block, find_number);
+      }
+      bool gt_reserve = (group_base + find_number) > RESERVE;
+      int gt_vote = g.ballot(gt_reserve);
+      K* key_ptr = sm_keys_ptr2[key_idx_block];
+      if (gt_vote == 0) {
+        do {
+          int digest_idx = __ffs(find_result) - 1;
+          if (digest_idx >= 0) {
+            find_result &= (find_result - 1);
+            int key_pos = rank * 4 + digest_idx;
+            sm_possible_pos[same_buf(i)][groupID * RESERVE + group_base] =
+                key_pos;
+            __pipeline_memcpy_async(sm_possible_keys[same_buf(i)] +
+                                        (groupID * RESERVE + group_base),
+                                    key_ptr + key_pos, sizeof(K));
+            group_base += 1;
+          } else {
+            break;
+          }
+        } while (true);
+      } else {
+        K target_key = sm_target_keys[key_idx_block];
+        sm_counts[key_idx_block] = 0;
+        int found_vote = 0;
+        bool found = false;
+        do {
+          int digest_idx = __ffs(find_result) - 1;
+          if (digest_idx >= 0) {
+            find_result &= (find_result - 1);
+            int key_pos = rank * 4 + digest_idx;
+            K possible_key = key_ptr[key_pos];
+            if (possible_key == target_key) {
+              found = true;
+              sm_counts[key_idx_block] = 1;
+              sm_possible_pos[same_buf(i)][groupID * RESERVE] = key_pos;
+              sm_possible_keys[same_buf(i)][groupID * RESERVE] = possible_key;
+            }
+          }
+          found_vote = g.ballot(found);
+          if (found_vote) break;
+          found_vote = digest_idx >= 0;
+        } while (g.any(found_vote));
+      }
+    } else {
+      __pipeline_wait_prior(3);
+    }
+    __pipeline_commit();
+
+    // Step3: verify keys and prefetch values from b2.
+    if (i > 0) {
+      int prev_block = groupID * GROUP_SIZE + i - 1;
+      int prev_skip = g.shfl(b1_found, i - 1);
+      if (!prev_skip) {
+        K target_key = sm_target_keys[prev_block];
+        // Read count BEFORE zeroing (sm_counts aliases sm_founds).
+        int possible_num = sm_counts[prev_block];
+        sm_founds[prev_block] = 0;
+        S* score_ptr = CopyScore::get_base_ptr(sm_keys_ptr2, prev_block);
+        VecV* value_ptr = sm_values_ptr2[prev_block];
+        __pipeline_wait_prior(3);
+        int key_pos;
+        bool found_flag = false;
+        if (rank < possible_num) {
+          K possible_key =
+              sm_possible_keys[diff_buf(i)][groupID * RESERVE + rank];
+          key_pos = sm_possible_pos[diff_buf(i)][groupID * RESERVE + rank];
+          if (possible_key == target_key) {
+            found_flag = true;
+            CopyScore::ldg_sts(sm_target_scores + prev_block,
+                               score_ptr + key_pos);
+          }
+        }
+        int found_vote = g.ballot(found_flag);
+        if (found_vote) {
+          VecV* v_dst = sm_vector[diff_buf(i)][groupID];
+          sm_founds[prev_block] = 1;
+          int src_lane = __ffs(found_vote) - 1;
+          int target_pos = g.shfl(key_pos, src_lane);
+          VecV* v_src = value_ptr + target_pos * dim;
+          CopyValue::ldg_sts(rank, v_dst, v_src, dim);
+        }
+      } else {
+        __pipeline_wait_prior(3);
+      }
+    }
+    __pipeline_commit();
+
+    // Step4: write back values from b2.
+    if (i > 1) {
+      int wb_block = groupID * GROUP_SIZE + i - 2;
+      int prev_skip = g.shfl(b1_found, i - 2);
+      if (!prev_skip) {
+        int key_idx_grid = blockIdx.x * blockDim.x + wb_block;
+        VecV* v_src = sm_vector[same_buf(i)][groupID];
+        VecV* v_dst = values + key_idx_grid * dim;
+        int found_flag = sm_founds[wb_block];
+        __pipeline_wait_prior(3);
+        if (found_flag > 0) {
+          S score_ = CopyScore::lgs(sm_target_scores + wb_block);
+          CopyValue::lds_stg(rank, v_dst, v_src, dim);
+          CopyScore::stg(scores + key_idx_grid, score_);
+        }
+      } else {
+        __pipeline_wait_prior(3);
+      }
+    }
+  }
+
+  // Pipeline emptying for b2: step3 for last key.
+  {
+    int key_idx_block = groupID * GROUP_SIZE + (loop_num - 1);
+    int last_skip = g.shfl(b1_found, loop_num - 1);
+    if (!last_skip) {
+      K target_key = sm_target_keys[key_idx_block];
+      // Read count BEFORE zeroing (sm_counts aliases sm_founds).
+      int possible_num = sm_counts[key_idx_block];
+      sm_founds[key_idx_block] = 0;
+      S* score_ptr = CopyScore::get_base_ptr(sm_keys_ptr2, key_idx_block);
+      VecV* value_ptr = sm_values_ptr2[key_idx_block];
+      __pipeline_wait_prior(1);
+      int key_pos;
+      bool found_flag = false;
+      if (rank < possible_num) {
+        key_pos = sm_possible_pos[diff_buf(loop_num)][groupID * RESERVE + rank];
+        K possible_key =
+            sm_possible_keys[diff_buf(loop_num)][groupID * RESERVE + rank];
+        if (target_key == possible_key) {
+          found_flag = true;
+          CopyScore::ldg_sts(sm_target_scores + key_idx_block,
+                             score_ptr + key_pos);
+        }
+      }
+      int found_vote = g.ballot(found_flag);
+      if (found_vote) {
+        sm_founds[key_idx_block] = 1;
+        int src_lane = __ffs(found_vote) - 1;
+        int target_pos = g.shfl(key_pos, src_lane);
+        VecV* v_src = value_ptr + target_pos * dim;
+        VecV* v_dst = sm_vector[diff_buf(loop_num)][groupID];
+        CopyValue::ldg_sts(rank, v_dst, v_src, dim);
+      }
+    } else {
+      __pipeline_wait_prior(1);
+    }
+  }
+  __pipeline_commit();
+
+  // Pipeline emptying: step4 for second-to-last key.
+  if (loop_num > 1) {
+    int key_idx_block = groupID * GROUP_SIZE + loop_num - 2;
+    int prev_skip = g.shfl(b1_found, loop_num - 2);
+    if (!prev_skip) {
+      int key_idx_grid = blockIdx.x * blockDim.x + key_idx_block;
+      VecV* v_src = sm_vector[same_buf(loop_num)][groupID];
+      VecV* v_dst = values + key_idx_grid * dim;
+      int found_flag = sm_founds[key_idx_block];
+      __pipeline_wait_prior(1);
+      if (found_flag > 0) {
+        S score_ = CopyScore::lgs(sm_target_scores + key_idx_block);
+        CopyValue::lds_stg(rank, v_dst, v_src, dim);
+        CopyScore::stg(scores + key_idx_grid, score_);
+      }
+    } else {
+      __pipeline_wait_prior(1);
+    }
+  }
+
+  // Pipeline emptying: step4 for last key.
+  {
+    int key_idx_block = groupID * GROUP_SIZE + loop_num - 1;
+    int last_skip = g.shfl(b1_found, loop_num - 1);
+    if (!last_skip) {
+      int key_idx_grid = blockIdx.x * blockDim.x + key_idx_block;
+      VecV* v_src = sm_vector[same_buf(loop_num + 1)][groupID];
+      VecV* v_dst = values + key_idx_grid * dim;
+      int found_flag = sm_founds[key_idx_block];
+      __pipeline_wait_prior(0);
+      if (found_flag > 0) {
+        S score_ = CopyScore::lgs(sm_target_scores + key_idx_block);
+        CopyValue::lds_stg(rank, v_dst, v_src, dim);
+        CopyScore::stg(scores + key_idx_grid, score_);
+      }
+    } else {
+      __pipeline_wait_prior(0);
+    }
+  }
+
+  // Finalize b2 pass: report found for keys found in b2.
+  if (rank < loop_num) {
+    int key_idx_block = groupID * GROUP_SIZE + rank;
+    int key_idx_grid = blockIdx.x * blockDim.x + key_idx_block;
+    if (b1_found == 0) {
+      // Key was not found in b1; report b2 result.
+      found_functor(key_idx_grid, sm_target_keys[key_idx_block],
+                    sm_founds[key_idx_block] > 0);
+    }
+  }
+}
+
+// --- Kernel Launchers ---
+
+template <typename K, typename V, typename S, typename CopyScore, typename VecV,
+          uint32_t ValueBufSize>
+struct LaunchDualBucketLookupV1 {
+  template <template <typename, typename, typename> typename LookupKernelParams>
+  static void launch_kernel(LookupKernelParams<K, V, S>& params,
+                            const int32_t* buckets_size, cudaStream_t& stream) {
+    constexpr int BLOCK_SIZE = 128;
+    constexpr int GROUP_SIZE = 32;
+    params.dim = params.dim * sizeof(V) / sizeof(VecV);
+    constexpr uint32_t VecSize = ValueBufSize / sizeof(VecV);
+    if (params.dim > (GROUP_SIZE * 2)) {
+      using CopyValue = CopyValueMultipleGroup<VecV, GROUP_SIZE>;
+      dual_bucket_pipeline_lookup_kernel_with_io<
+          K, V, S, VecV, CopyScore, CopyValue, decltype(params.found_functor),
+          VecSize>
+          <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
+              params.buckets, buckets_size, params.buckets_num, params.dim,
+              params.keys, reinterpret_cast<VecV*>(params.values),
+              params.scores, params.found_functor, params.n);
+    } else if (params.dim > GROUP_SIZE) {
+      using CopyValue = CopyValueTwoGroup<VecV, GROUP_SIZE>;
+      dual_bucket_pipeline_lookup_kernel_with_io<
+          K, V, S, VecV, CopyScore, CopyValue, decltype(params.found_functor),
+          VecSize>
+          <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
+              params.buckets, buckets_size, params.buckets_num, params.dim,
+              params.keys, reinterpret_cast<VecV*>(params.values),
+              params.scores, params.found_functor, params.n);
+    } else {
+      using CopyValue = CopyValueOneGroup<VecV, GROUP_SIZE>;
+      dual_bucket_pipeline_lookup_kernel_with_io<
+          K, V, S, VecV, CopyScore, CopyValue, decltype(params.found_functor),
+          VecSize>
+          <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
+              params.buckets, buckets_size, params.buckets_num, params.dim,
+              params.keys, reinterpret_cast<VecV*>(params.values),
+              params.scores, params.found_functor, params.n);
+    }
+  }
+};
+
+// --- Kernel Selector ---
+
+template <typename K, typename V, typename S = uint64_t,
+          typename ArchTag = Sm80>
+struct SelectDualBucketLookupKernel {
+  using ValueBufConfig = LookupValueBufConfig<ArchTag>;
+
+  static inline uint32_t max_value_size() {
+    return ValueBufConfig::size_pipeline_v1;
+  }
+
+  template <template <typename, typename, typename> typename LookupKernelParams>
+  static void select_kernel(LookupKernelParams<K, V, S>& params,
+                            const int32_t* buckets_size, cudaStream_t& stream) {
+    constexpr int BUCKET_SIZE = 128;
+    constexpr uint32_t buf_size_v1 = ValueBufConfig::size_pipeline_v1;
+
+    uint32_t total_value_size = static_cast<uint32_t>(params.dim * sizeof(V));
+
+    // For dual-bucket lookup, we use v1 kernel (32 threads/key) only.
+    if (params.scores == nullptr) {
+      using CopyScore = CopyScoreEmpty<S, K, BUCKET_SIZE>;
+      if (total_value_size % sizeof(float4) == 0) {
+        using VecV = float4;
+        LaunchDualBucketLookupV1<K, V, S, CopyScore, VecV,
+                                 buf_size_v1>::launch_kernel(params,
+                                                             buckets_size,
+                                                             stream);
+      } else if (total_value_size % sizeof(float2) == 0) {
+        using VecV = float2;
+        LaunchDualBucketLookupV1<K, V, S, CopyScore, VecV,
+                                 buf_size_v1>::launch_kernel(params,
+                                                             buckets_size,
+                                                             stream);
+      } else if (total_value_size % sizeof(float) == 0) {
+        using VecV = float;
+        LaunchDualBucketLookupV1<K, V, S, CopyScore, VecV,
+                                 buf_size_v1>::launch_kernel(params,
+                                                             buckets_size,
+                                                             stream);
+      } else if (total_value_size % sizeof(uint16_t) == 0) {
+        using VecV = uint16_t;
+        LaunchDualBucketLookupV1<K, V, S, CopyScore, VecV,
+                                 buf_size_v1>::launch_kernel(params,
+                                                             buckets_size,
+                                                             stream);
+      } else {
+        using VecV = uint8_t;
+        LaunchDualBucketLookupV1<K, V, S, CopyScore, VecV,
+                                 buf_size_v1>::launch_kernel(params,
+                                                             buckets_size,
+                                                             stream);
+      }
+    } else {
+      using CopyScore = CopyScoreByPassCache<S, K, BUCKET_SIZE>;
+      if (total_value_size % sizeof(float4) == 0) {
+        using VecV = float4;
+        LaunchDualBucketLookupV1<K, V, S, CopyScore, VecV,
+                                 buf_size_v1>::launch_kernel(params,
+                                                             buckets_size,
+                                                             stream);
+      } else if (total_value_size % sizeof(float2) == 0) {
+        using VecV = float2;
+        LaunchDualBucketLookupV1<K, V, S, CopyScore, VecV,
+                                 buf_size_v1>::launch_kernel(params,
+                                                             buckets_size,
+                                                             stream);
+      } else if (total_value_size % sizeof(float) == 0) {
+        using VecV = float;
+        LaunchDualBucketLookupV1<K, V, S, CopyScore, VecV,
+                                 buf_size_v1>::launch_kernel(params,
+                                                             buckets_size,
+                                                             stream);
+      } else if (total_value_size % sizeof(uint16_t) == 0) {
+        using VecV = uint16_t;
+        LaunchDualBucketLookupV1<K, V, S, CopyScore, VecV,
+                                 buf_size_v1>::launch_kernel(params,
+                                                             buckets_size,
+                                                             stream);
+      } else {
+        using VecV = uint8_t;
+        LaunchDualBucketLookupV1<K, V, S, CopyScore, VecV,
+                                 buf_size_v1>::launch_kernel(params,
+                                                             buckets_size,
+                                                             stream);
+      }
+    }
+  }
+};
+
+}  // namespace merlin
+}  // namespace nv

--- a/include/merlin/core_kernels/dual_bucket_upsert.cuh
+++ b/include/merlin/core_kernels/dual_bucket_upsert.cuh
@@ -1,0 +1,775 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "dual_bucket_utils.cuh"
+#include "kernel_utils.cuh"
+
+namespace nv {
+namespace merlin {
+
+/**
+ * Dual-bucket pipeline upsert kernel — True Two-Choice.
+ *
+ * Implements dual-bucket insert_or_assign with three distinct phases:
+ *   Phase 0: DUPLICATE detection in BOTH buckets (no empty-slot occupation)
+ *   Phase 1: D1 Two-Choice load-balance — compare bucket sizes, insert into
+ *            the emptier bucket first, fallback to the other
+ *   Phase 2: D2 score-eviction — when both buckets full, evict the entry
+ *            with the global minimum score across both buckets
+ *
+ * Key invariant: DUPLICATE search completes in BOTH buckets before any
+ * empty-slot insertion attempt. This ensures correct insert_or_assign
+ * semantics (no spurious duplicates across buckets).
+ *
+ * Concurrent model: pure slot-level CAS (no per-bucket Mutex).
+ * Constraint: unique_key=true (caller guarantees no duplicate keys in batch).
+ *
+ * Based on pipeline_upsert_kernel_with_io architecture:
+ * - 32 threads per key (GROUP_SIZE)
+ * - 128-thread blocks
+ * - 128-slot buckets
+ * - 4-stage software pipeline
+ */
+template <class K, class V, class S, class VecV, int BLOCK_SIZE = 128,
+          int Strategy = 0>
+__global__ void dual_bucket_pipeline_upsert_kernel_with_io(
+    Bucket<K, V, S>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
+    const uint64_t buckets_num, const uint32_t dim, const K* __restrict__ keys,
+    const VecV* __restrict__ values, const S* __restrict__ scores, uint64_t n,
+    const S global_epoch) {
+  constexpr uint32_t BUCKET_SIZE = 128;
+  constexpr uint32_t GROUP_SIZE = 32;
+  constexpr uint32_t Comp_LEN = sizeof(VecD_Comp) / sizeof(D);
+  constexpr uint32_t Load_LEN = sizeof(VecD_Load) / sizeof(D);
+  constexpr uint32_t Load_LEN_S = sizeof(byte16) / sizeof(S);
+
+  using BUCKET = Bucket<K, V, S>;
+  using CopyValue = CopyValueMultipleGroup<VecV, GROUP_SIZE>;
+  using SMM = SharedMemoryManager_Pipeline_Upsert<K, V, S, VecV, BLOCK_SIZE,
+                                                  GROUP_SIZE, BUCKET_SIZE>;
+  using ScoreFunctor_ = ScoreFunctor<K, V, S, Strategy>;
+
+  __shared__ extern __align__(alignof(byte16)) byte smem[];
+
+  auto g = cg::tiled_partition<GROUP_SIZE>(cg::this_thread_block());
+  uint32_t tx = threadIdx.x;
+  uint32_t kv_idx = blockIdx.x * blockDim.x + tx;
+  K key{static_cast<K>(EMPTY_KEY)};
+  VecD_Comp target_digests;
+  K* bucket_keys_ptr1{nullptr};
+  K* bucket_keys_ptr2{nullptr};
+  VecV* bucket_values_ptr2{nullptr};
+  int* bucket_size_ptr2{nullptr};
+  OccupyResult occupy_result{OccupyResult::INITIAL};
+  uint32_t key_pos = 0;
+  uint32_t key_pos2 = 0;  // b2 start position (independent from b1)
+  int target_bucket = 1;  // 1 = b1, 2 = b2
+
+  if (kv_idx < n) {
+    key = keys[kv_idx];
+    if (scores != nullptr) {
+      S* sm_param_scores = SMM::param_scores(smem);
+      __pipeline_memcpy_async(sm_param_scores + tx, scores + kv_idx, sizeof(S));
+    }
+    if (!IS_RESERVED_KEY<K>(key)) {
+      const K hashed_key = Murmur3HashDevice(key);
+      // Dual-bucket digest from bit[56:63].
+      target_digests = dual_bucket_digests_from_hashed<K>(hashed_key);
+
+      // Dual-bucket indices (centralized in dual_bucket_utils.cuh).
+      size_t bkt_idx1, bkt_idx2;
+      get_dual_bucket_indices<K>(hashed_key, buckets_num, bkt_idx1, bkt_idx2);
+
+      // b1 setup (stored in SMM shared memory).
+      const uint32_t lo = static_cast<uint32_t>(hashed_key);
+      uint64_t global_idx1 =
+          static_cast<uint64_t>(lo % (buckets_num * BUCKET_SIZE));
+      key_pos = get_start_position(global_idx1, BUCKET_SIZE);
+
+      // b2 start position from high 32 bits (independent from b1).
+      const uint32_t hi =
+          static_cast<uint32_t>(static_cast<uint64_t>(hashed_key) >> 32);
+      uint64_t global_idx2 =
+          static_cast<uint64_t>(hi % (buckets_num * BUCKET_SIZE));
+      key_pos2 = get_start_position(global_idx2, BUCKET_SIZE);
+
+      int** sm_buckets_size_ptr = SMM::buckets_size_ptr(smem);
+      sm_buckets_size_ptr[tx] = buckets_size + bkt_idx1;
+
+      BUCKET* bucket1 = buckets + bkt_idx1;
+      bucket_keys_ptr1 = reinterpret_cast<K*>(bucket1->keys(0));
+      VecV** sm_bucket_values_ptr = SMM::bucket_values_ptr(smem);
+      __pipeline_memcpy_async(sm_bucket_values_ptr + tx, &(bucket1->vectors),
+                              sizeof(VecV*));
+
+      // b2 setup (stored in registers, broadcast via warp shuffle).
+      BUCKET* bucket2 = buckets + bkt_idx2;
+      bucket_keys_ptr2 = reinterpret_cast<K*>(bucket2->keys(0));
+      bucket_values_ptr2 = reinterpret_cast<VecV*>(bucket2->vectors);
+      bucket_size_ptr2 = buckets_size + bkt_idx2;
+    } else {
+      occupy_result = OccupyResult::ILLEGAL;
+    }
+  } else {
+    occupy_result = OccupyResult::ILLEGAL;
+  }
+
+  uint32_t rank = g.thread_rank();
+  uint32_t groupID = threadIdx.x / GROUP_SIZE;
+
+  // =========== Main pipeline loop (processes one key per iteration)
+  // =========== True Two-Choice algorithm for each key i in the warp:
+  //   Phase 0: DUPLICATE detection in BOTH b1 and b2 (no empty occupation)
+  //   Phase 1: D1 Two-Choice — compare bucket sizes, try emptier bucket first
+  //   Phase 2: D2 score-eviction when both buckets are full
+
+  auto occupy_result_next = g.shfl(occupy_result, 0);
+  auto keys_ptr_next = g.shfl(bucket_keys_ptr1, 0);
+
+  // Prefetch b1 digests for first key.
+  if (occupy_result_next == OccupyResult::INITIAL) {
+    D* sm_bucket_digests = SMM::bucket_digests(smem, groupID, 0);
+    D* dst = sm_bucket_digests + rank * Load_LEN;
+    D* src = BUCKET::digests(keys_ptr_next, BUCKET_SIZE, rank * Load_LEN);
+    if (rank * Load_LEN < BUCKET_SIZE) {
+      __pipeline_memcpy_async(dst, src, sizeof(VecD_Load));
+    }
+  }
+  __pipeline_commit();
+  __pipeline_commit();
+  __pipeline_commit();
+
+  for (int32_t i = 0; i < GROUP_SIZE; i++) {
+    // === Step 1: Prefetch b1 digests for next key ===
+    if (i + 1 < GROUP_SIZE) {
+      auto occupy_result_next = g.shfl(occupy_result, i + 1);
+      auto keys_ptr_next = g.shfl(bucket_keys_ptr1, i + 1);
+      if (occupy_result_next == OccupyResult::INITIAL) {
+        D* sm_bucket_digests = SMM::bucket_digests(smem, groupID, diff_buf(i));
+        D* dst = sm_bucket_digests + rank * Load_LEN;
+        D* src = BUCKET::digests(keys_ptr_next, BUCKET_SIZE, rank * Load_LEN);
+        if (rank * Load_LEN < BUCKET_SIZE) {
+          __pipeline_memcpy_async(dst, src, sizeof(VecD_Load));
+        }
+      }
+    }
+    __pipeline_commit();
+
+    // === Step 2: Three-phase True Two-Choice probe ===
+    auto occupy_result_cur = g.shfl(occupy_result, i);
+    if (occupy_result_cur == OccupyResult::INITIAL) {
+      uint32_t tx_cur = groupID * GROUP_SIZE + i;
+      int** sm_buckets_size_ptr = SMM::buckets_size_ptr(smem);
+      auto bucket_size_ptr1 = sm_buckets_size_ptr[tx_cur];
+      K key_cur = g.shfl(key, i);
+      auto target_digests_cur = g.shfl(target_digests, i);
+      auto start_pos_cur = g.shfl(key_pos, i);
+      auto keys_ptr_cur = g.shfl(bucket_keys_ptr1, i);
+
+      // b2 info for key i (shuffled from owning thread).
+      auto keys_ptr2_cur = g.shfl(bucket_keys_ptr2, i);
+      auto bsize_ptr2_cur = reinterpret_cast<int*>(static_cast<uintptr_t>(
+          g.shfl(static_cast<unsigned long long>(
+                     reinterpret_cast<uintptr_t>(bucket_size_ptr2)),
+                 i)));
+      auto start_pos2_cur = g.shfl(key_pos2, i);
+
+      __pipeline_wait_prior(3);
+      D* digest_src = SMM::bucket_digests(smem, groupID, same_buf(i));
+
+      // b1 probe offset (from b1's hash).
+      uint32_t start_offset = start_pos_cur / Comp_LEN;
+      uint32_t probe_offset =
+          Comp_LEN * ((start_offset + rank) & (GROUP_SIZE - 1));
+      VecD_Comp probe_digests =
+          *reinterpret_cast<VecD_Comp*>(digest_src + probe_offset);
+      uint32_t cmp_result = __vcmpeq4(probe_digests, target_digests_cur);
+      cmp_result &= 0x01010101;
+
+      // b2 probe offset (from b2's independent hash).
+      uint32_t start_offset2 = start_pos2_cur / Comp_LEN;
+      uint32_t b2_probe_offset =
+          Comp_LEN * ((start_offset2 + rank) & (GROUP_SIZE - 1));
+      // Load b2 digests (synchronous read).
+      D* b2_digests_ptr = BUCKET::digests(keys_ptr2_cur, BUCKET_SIZE, 0);
+      VecD_Comp b2_probe_digests =
+          *reinterpret_cast<VecD_Comp*>(b2_digests_ptr + b2_probe_offset);
+      uint32_t b2_cmp = __vcmpeq4(b2_probe_digests, target_digests_cur);
+      b2_cmp &= 0x01010101;
+
+      // ============================================================
+      // Phase 0: DUPLICATE detection in BOTH buckets
+      // ============================================================
+
+      // --- Phase 0a: DUPLICATE scan in b1 ---
+      uint32_t possible_pos = 0;
+      bool result = false;
+      {
+        uint32_t cmp_copy = cmp_result;
+        do {
+          if (cmp_copy == 0) break;
+          int32_t index = (__ffs(cmp_copy) - 1) >> 3;
+          cmp_copy &= (cmp_copy - 1);
+          possible_pos = probe_offset + index;
+          auto current_key = BUCKET::keys(keys_ptr_cur, possible_pos);
+          K expected_key = key_cur;
+          result = current_key->compare_exchange_strong(
+              expected_key, static_cast<K>(LOCKED_KEY),
+              cuda::std::memory_order_acquire, cuda::std::memory_order_relaxed);
+        } while (!result);
+      }
+
+      uint32_t found_vote = g.ballot(result);
+      if (found_vote) {
+        // DUPLICATE found in b1 -> update in place.
+        int32_t src_lane = __ffs(found_vote) - 1;
+        possible_pos = g.shfl(possible_pos, src_lane);
+        if (rank == i) {
+          occupy_result = OccupyResult::DUPLICATE;
+          key_pos = possible_pos;
+          target_bucket = 1;
+          S* sm_param_scores = SMM::param_scores(smem);
+          // Note: desired_when_missed is intentionally used here for
+          // DUPLICATE keys.  For kCustomized strategy the actual score
+          // semantics are determined by update_with_digest, which
+          // overwrites the score unconditionally.  The naming is
+          // inherited from the single-bucket API and does not imply
+          // "key was absent".
+          S score = ScoreFunctor_::desired_when_missed(sm_param_scores, tx,
+                                                       global_epoch);
+          D digest = get_dual_bucket_digest<K>(key);
+          ScoreFunctor_::update_with_digest(bucket_keys_ptr1, key_pos,
+                                            sm_param_scores, tx, score,
+                                            BUCKET_SIZE, digest, false);
+        }
+      }
+
+      // --- Phase 0b: DUPLICATE scan in b2 (only if not found in b1) ---
+      occupy_result_cur = g.shfl(occupy_result, i);
+      if (occupy_result_cur == OccupyResult::INITIAL) {
+        result = false;
+        possible_pos = 0;
+        {
+          uint32_t cmp_copy = b2_cmp;
+          do {
+            if (cmp_copy == 0) break;
+            int32_t index = (__ffs(cmp_copy) - 1) >> 3;
+            cmp_copy &= (cmp_copy - 1);
+            possible_pos = b2_probe_offset + index;
+            auto current_key = BUCKET::keys(keys_ptr2_cur, possible_pos);
+            K expected_key = key_cur;
+            result = current_key->compare_exchange_strong(
+                expected_key, static_cast<K>(LOCKED_KEY),
+                cuda::std::memory_order_acquire,
+                cuda::std::memory_order_relaxed);
+          } while (!result);
+        }
+
+        found_vote = g.ballot(result);
+        if (found_vote) {
+          // DUPLICATE found in b2.
+          int32_t src_lane = __ffs(found_vote) - 1;
+          possible_pos = g.shfl(possible_pos, src_lane);
+          if (rank == i) {
+            occupy_result = OccupyResult::DUPLICATE;
+            key_pos = possible_pos;
+            target_bucket = 2;
+            S* sm_param_scores = SMM::param_scores(smem);
+            // See Phase 0a comment: desired_when_missed is used for
+            // DUPLICATE keys; actual semantics governed by
+            // update_with_digest.
+            S score = ScoreFunctor_::desired_when_missed(sm_param_scores, tx,
+                                                         global_epoch);
+            D digest = get_dual_bucket_digest<K>(key);
+            ScoreFunctor_::update_with_digest(bucket_keys_ptr2, key_pos,
+                                              sm_param_scores, tx, score,
+                                              BUCKET_SIZE, digest, false);
+          }
+        }
+      }
+
+      // ============================================================
+      // Phase 1: D1 Two-Choice load-balanced EMPTY insertion
+      // ============================================================
+      occupy_result_cur = g.shfl(occupy_result, i);
+      if (occupy_result_cur == OccupyResult::INITIAL) {
+        auto bucket_size1 = *bucket_size_ptr1;
+        auto bucket_size2 = *bsize_ptr2_cur;
+
+        // True Two-Choice: prefer the emptier bucket.
+        bool prefer_b1 = (bucket_size1 <= bucket_size2);
+
+        // First bucket (emptier one).
+        K* first_keys_ptr = prefer_b1 ? keys_ptr_cur : keys_ptr2_cur;
+        int* first_bsize_ptr = prefer_b1 ? bucket_size_ptr1 : bsize_ptr2_cur;
+        int first_size = prefer_b1 ? bucket_size1 : bucket_size2;
+        VecD_Comp first_probe_digests =
+            prefer_b1 ? probe_digests : b2_probe_digests;
+        uint32_t first_probe_offset =
+            prefer_b1 ? probe_offset : b2_probe_offset;
+        int first_bucket_id = prefer_b1 ? 1 : 2;
+
+        // Second bucket (fuller one).
+        K* second_keys_ptr = prefer_b1 ? keys_ptr2_cur : keys_ptr_cur;
+        int* second_bsize_ptr = prefer_b1 ? bsize_ptr2_cur : bucket_size_ptr1;
+        int second_size = prefer_b1 ? bucket_size2 : bucket_size1;
+        VecD_Comp second_probe_digests =
+            prefer_b1 ? b2_probe_digests : probe_digests;
+        uint32_t second_probe_offset =
+            prefer_b1 ? b2_probe_offset : probe_offset;
+        int second_bucket_id = prefer_b1 ? 2 : 1;
+
+        // --- Try EMPTY in first (emptier) bucket ---
+        if (first_size < BUCKET_SIZE) {
+          VecD_Comp empty_digests_ = dual_bucket_empty_digests<K>();
+          uint32_t empty_result =
+              __vcmpeq4(first_probe_digests, empty_digests_);
+          empty_result &= 0x01010101;
+          result = false;
+          possible_pos = 0;
+          for (int32_t offset = 0; offset < GROUP_SIZE; offset += 1) {
+            if (rank == offset) {
+              do {
+                if (empty_result == 0) break;
+                int32_t index = (__ffs(empty_result) - 1) >> 3;
+                empty_result &= (empty_result - 1);
+                possible_pos = first_probe_offset + index;
+                auto current_key = BUCKET::keys(first_keys_ptr, possible_pos);
+                K expected_key = static_cast<K>(EMPTY_KEY);
+                result = current_key->compare_exchange_strong(
+                    expected_key, static_cast<K>(LOCKED_KEY),
+                    cuda::std::memory_order_acquire,
+                    cuda::std::memory_order_relaxed);
+              } while (!result);
+            }
+            found_vote = g.ballot(result);
+            if (found_vote) {
+              int32_t src_lane = __ffs(found_vote) - 1;
+              possible_pos = g.shfl(possible_pos, src_lane);
+              if (rank == i) {
+                occupy_result = OccupyResult::OCCUPIED_EMPTY;
+                key_pos = possible_pos;
+                target_bucket = first_bucket_id;
+                S* sm_param_scores = SMM::param_scores(smem);
+                S score = ScoreFunctor_::desired_when_missed(sm_param_scores,
+                                                             tx, global_epoch);
+                D digest = get_dual_bucket_digest<K>(key);
+                K* target_keys = (first_bucket_id == 1) ? bucket_keys_ptr1
+                                                        : bucket_keys_ptr2;
+                ScoreFunctor_::update_with_digest(target_keys, key_pos,
+                                                  sm_param_scores, tx, score,
+                                                  BUCKET_SIZE, digest, true);
+                atomicAdd(first_bsize_ptr, 1);
+              }
+              break;
+            }
+          }
+        }
+
+        // --- Try EMPTY in second (fuller) bucket (fallback) ---
+        occupy_result_cur = g.shfl(occupy_result, i);
+        if (occupy_result_cur == OccupyResult::INITIAL &&
+            second_size < BUCKET_SIZE) {
+          VecD_Comp empty_digests_ = dual_bucket_empty_digests<K>();
+          uint32_t empty_result =
+              __vcmpeq4(second_probe_digests, empty_digests_);
+          empty_result &= 0x01010101;
+          result = false;
+          possible_pos = 0;
+          for (int32_t offset = 0; offset < GROUP_SIZE; offset += 1) {
+            if (rank == offset) {
+              do {
+                if (empty_result == 0) break;
+                int32_t index = (__ffs(empty_result) - 1) >> 3;
+                empty_result &= (empty_result - 1);
+                possible_pos = second_probe_offset + index;
+                auto current_key = BUCKET::keys(second_keys_ptr, possible_pos);
+                K expected_key = static_cast<K>(EMPTY_KEY);
+                result = current_key->compare_exchange_strong(
+                    expected_key, static_cast<K>(LOCKED_KEY),
+                    cuda::std::memory_order_acquire,
+                    cuda::std::memory_order_relaxed);
+              } while (!result);
+            }
+            found_vote = g.ballot(result);
+            if (found_vote) {
+              int32_t src_lane = __ffs(found_vote) - 1;
+              possible_pos = g.shfl(possible_pos, src_lane);
+              if (rank == i) {
+                occupy_result = OccupyResult::OCCUPIED_EMPTY;
+                key_pos = possible_pos;
+                target_bucket = second_bucket_id;
+                S* sm_param_scores = SMM::param_scores(smem);
+                S score = ScoreFunctor_::desired_when_missed(sm_param_scores,
+                                                             tx, global_epoch);
+                D digest = get_dual_bucket_digest<K>(key);
+                K* target_keys = (second_bucket_id == 1) ? bucket_keys_ptr1
+                                                         : bucket_keys_ptr2;
+                ScoreFunctor_::update_with_digest(target_keys, key_pos,
+                                                  sm_param_scores, tx, score,
+                                                  BUCKET_SIZE, digest, true);
+                atomicAdd(second_bsize_ptr, 1);
+              }
+              break;
+            }
+          }
+        }
+      }
+
+      // ============================================================
+      // Phase 2: D2 Score Eviction (both buckets full)
+      // ============================================================
+      occupy_result_cur = g.shfl(occupy_result, i);
+      if (occupy_result_cur == OccupyResult::INITIAL) {
+        S* sm_param_scores = SMM::param_scores(smem);
+        S score_cur = ScoreFunctor_::desired_when_missed(sm_param_scores,
+                                                         tx_cur, global_epoch);
+
+        S* b1_scores = BUCKET::scores(keys_ptr_cur, BUCKET_SIZE, 0);
+        S* b2_scores = BUCKET::scores(keys_ptr2_cur, BUCKET_SIZE, 0);
+
+        // Cache scores in per-thread registers for eviction retry.
+        constexpr int SCORES_PER_THREAD =
+            BUCKET_SIZE / (GROUP_SIZE * Load_LEN_S) * Load_LEN_S;
+        S b1_cached[SCORES_PER_THREAD];
+        int b1_pos_cached[SCORES_PER_THREAD];
+        S b2_cached[SCORES_PER_THREAD];
+        int b2_pos_cached[SCORES_PER_THREAD];
+        {
+          int idx = 0;
+          for (int j = 0; j < BUCKET_SIZE; j += GROUP_SIZE * Load_LEN_S) {
+            S tmp[Load_LEN_S];
+            *reinterpret_cast<byte16*>(tmp) =
+                *reinterpret_cast<byte16*>(b1_scores + rank * Load_LEN_S + j);
+            for (int k = 0; k < Load_LEN_S; k++) {
+              b1_cached[idx] = tmp[k];
+              b1_pos_cached[idx] = rank * Load_LEN_S + j + k;
+              idx++;
+            }
+          }
+        }
+        {
+          int idx = 0;
+          for (int j = 0; j < BUCKET_SIZE; j += GROUP_SIZE * Load_LEN_S) {
+            S tmp[Load_LEN_S];
+            *reinterpret_cast<byte16*>(tmp) =
+                *reinterpret_cast<byte16*>(b2_scores + rank * Load_LEN_S + j);
+            for (int k = 0; k < Load_LEN_S; k++) {
+              b2_cached[idx] = tmp[k];
+              b2_pos_cached[idx] = rank * Load_LEN_S + j + k;
+              idx++;
+            }
+          }
+        }
+
+        // Eviction retry loop.
+        while (true) {
+          occupy_result_cur = g.shfl(occupy_result, i);
+          if (occupy_result_cur != OccupyResult::INITIAL) break;
+
+          // Find per-thread min for b1 and b2 from cached scores.
+          S min_b1_local = static_cast<S>(MAX_SCORE);
+          int min_b1_idx = -1;
+          for (int s = 0; s < SCORES_PER_THREAD; s++) {
+            if (b1_cached[s] < min_b1_local) {
+              min_b1_local = b1_cached[s];
+              min_b1_idx = s;
+            }
+          }
+          S min_b2_local = static_cast<S>(MAX_SCORE);
+          int min_b2_idx = -1;
+          for (int s = 0; s < SCORES_PER_THREAD; s++) {
+            if (b2_cached[s] < min_b2_local) {
+              min_b2_local = b2_cached[s];
+              min_b2_idx = s;
+            }
+          }
+
+          S min_b1_global = cg::reduce(g, min_b1_local, cg::less<S>());
+          S min_b2_global = cg::reduce(g, min_b2_local, cg::less<S>());
+          S overall_min =
+              (min_b1_global <= min_b2_global) ? min_b1_global : min_b2_global;
+
+          // REFUSED: new score too low to evict anything.
+          if (score_cur < overall_min) {
+            if (rank == i) {
+              occupy_result = OccupyResult::REFUSED;
+            }
+            break;
+          }
+
+          // Pick the bucket with lower min_score (Two-Choice eviction).
+          bool use_b1 = (min_b1_global <= min_b2_global);
+          S min_score_local = use_b1 ? min_b1_local : min_b2_local;
+          int min_local_idx = use_b1 ? min_b1_idx : min_b2_idx;
+          int min_pos_local = (min_local_idx >= 0)
+                                  ? (use_b1 ? b1_pos_cached[min_local_idx]
+                                            : b2_pos_cached[min_local_idx])
+                                  : -1;
+          S min_score_global = use_b1 ? min_b1_global : min_b2_global;
+          K* evict_keys_ptr = use_b1 ? keys_ptr_cur : keys_ptr2_cur;
+          int* evict_bsize_ptr = use_b1 ? bucket_size_ptr1 : bsize_ptr2_cur;
+
+          uint32_t vote = g.ballot(min_score_local <= min_score_global);
+          if (vote) {
+            int src_lane = __ffs(vote) - 1;
+            int min_pos_evict = g.shfl(min_pos_local, src_lane);
+
+            // Mark this position as visited for the winning thread.
+            if (use_b1) {
+              int visited_idx = g.shfl(min_local_idx, src_lane);
+              if (rank == src_lane && visited_idx >= 0)
+                b1_cached[visited_idx] = static_cast<S>(MAX_SCORE);
+            } else {
+              int visited_idx = g.shfl(min_local_idx, src_lane);
+              if (rank == src_lane && visited_idx >= 0)
+                b2_cached[visited_idx] = static_cast<S>(MAX_SCORE);
+            }
+
+            if (rank == i) {
+              auto min_score_key = BUCKET::keys(evict_keys_ptr, min_pos_evict);
+              auto expected_key =
+                  min_score_key->load(cuda::std::memory_order_relaxed);
+              if (expected_key != static_cast<K>(LOCKED_KEY) &&
+                  expected_key != static_cast<K>(EMPTY_KEY)) {
+                bool cas_ok = min_score_key->compare_exchange_strong(
+                    expected_key, static_cast<K>(LOCKED_KEY),
+                    cuda::std::memory_order_acquire,
+                    cuda::std::memory_order_relaxed);
+                if (cas_ok) {
+                  S* score_ptr = BUCKET::scores(evict_keys_ptr, BUCKET_SIZE,
+                                                min_pos_evict);
+                  auto verify_score_ptr =
+                      reinterpret_cast<AtomicScore<S>*>(score_ptr);
+                  auto verify_score =
+                      verify_score_ptr->load(cuda::std::memory_order_relaxed);
+                  if (verify_score <= min_score_global) {
+                    if (expected_key == static_cast<K>(RECLAIM_KEY)) {
+                      occupy_result = OccupyResult::OCCUPIED_RECLAIMED;
+                      atomicAdd(evict_bsize_ptr, 1);
+                    } else {
+                      occupy_result = OccupyResult::EVICT;
+                    }
+                    key_pos = min_pos_evict;
+                    target_bucket = use_b1 ? 1 : 2;
+                    K* target_keys_ptr =
+                        use_b1 ? bucket_keys_ptr1 : bucket_keys_ptr2;
+                    D digest = get_dual_bucket_digest<K>(key);
+                    ScoreFunctor_::update_with_digest(
+                        target_keys_ptr, key_pos, sm_param_scores, tx,
+                        score_cur, BUCKET_SIZE, digest, true);
+                  } else {
+                    min_score_key->store(expected_key,
+                                         cuda::std::memory_order_release);
+                  }
+                }
+              }
+            }
+          } else {
+            // No thread holds the minimum — all positions exhausted.
+            if (rank == i) {
+              occupy_result = OccupyResult::REFUSED;
+            }
+            break;
+          }
+        }  // while eviction retry
+      }
+    }  // end of INITIAL check
+
+    // === Step 3: Prefetch values to shared memory for previous key ===
+    if (i > 0) {
+      auto occupy_result_prev = g.shfl(occupy_result, i - 1);
+      if (occupy_result_prev != OccupyResult::ILLEGAL &&
+          occupy_result_prev != OccupyResult::REFUSED) {
+        VecV* dst = SMM::values_buffer(smem, groupID, diff_buf(i), dim);
+        auto kv_idx_cur = g.shfl(kv_idx, i - 1);
+        const VecV* src = values + kv_idx_cur * dim;
+        CopyValue::ldg_sts(rank, dst, src, dim);
+      }
+    }
+    __pipeline_commit();
+
+    // === Step 4: Write values for key (i-2) ===
+    if (i > 1) {
+      auto occupy_result_wb = g.shfl(occupy_result, i - 2);
+      if (occupy_result_wb != OccupyResult::ILLEGAL &&
+          occupy_result_wb != OccupyResult::REFUSED) {
+        VecV* src = SMM::values_buffer(smem, groupID, same_buf(i), dim);
+        auto key_pos_wb = g.shfl(key_pos, i - 2);
+        auto target_bucket_wb = g.shfl(target_bucket, i - 2);
+
+        // Get the correct values pointer for the target bucket.
+        VecV* dst;
+        if (target_bucket_wb == 1) {
+          VecV** sm_bucket_values_ptr = SMM::bucket_values_ptr(smem);
+          dst = sm_bucket_values_ptr[groupID * GROUP_SIZE + i - 2] +
+                key_pos_wb * dim;
+        } else {
+          auto bv2 = g.shfl(bucket_values_ptr2, i - 2);
+          dst = bv2 + key_pos_wb * dim;
+        }
+        __pipeline_wait_prior(3);
+        CopyValue::lds_stg(rank, dst, src, dim);
+
+        // Unlock key.
+        if (rank == i - 2) {
+          K* target_keys_ptr =
+              (target_bucket == 1) ? bucket_keys_ptr1 : bucket_keys_ptr2;
+          auto key_address = BUCKET::keys(target_keys_ptr, key_pos);
+          key_address->store(key, cuda::std::memory_order_release);
+        }
+      }
+    }
+  }  // end main loop
+
+  // =========== Pipeline draining ===========
+
+  // Step 3 for last key (i = GROUP_SIZE - 1).
+  {
+    auto occupy_result_prev = g.shfl(occupy_result, GROUP_SIZE - 1);
+    if (occupy_result_prev != OccupyResult::ILLEGAL &&
+        occupy_result_prev != OccupyResult::REFUSED) {
+      VecV* dst = SMM::values_buffer(smem, groupID, diff_buf(GROUP_SIZE), dim);
+      auto kv_idx_cur = g.shfl(kv_idx, GROUP_SIZE - 1);
+      const VecV* src = values + kv_idx_cur * dim;
+      CopyValue::ldg_sts(rank, dst, src, dim);
+    }
+  }
+  __pipeline_commit();
+
+  // Step 4 for key (GROUP_SIZE - 2).
+  {
+    auto occupy_result_wb = g.shfl(occupy_result, GROUP_SIZE - 2);
+    if (occupy_result_wb != OccupyResult::ILLEGAL &&
+        occupy_result_wb != OccupyResult::REFUSED) {
+      VecV* src = SMM::values_buffer(smem, groupID, same_buf(GROUP_SIZE), dim);
+      auto key_pos_wb = g.shfl(key_pos, GROUP_SIZE - 2);
+      auto target_bucket_wb = g.shfl(target_bucket, GROUP_SIZE - 2);
+      VecV* dst;
+      if (target_bucket_wb == 1) {
+        VecV** sm_bucket_values_ptr = SMM::bucket_values_ptr(smem);
+        dst = sm_bucket_values_ptr[groupID * GROUP_SIZE + GROUP_SIZE - 2] +
+              key_pos_wb * dim;
+      } else {
+        auto bv2 = g.shfl(bucket_values_ptr2, GROUP_SIZE - 2);
+        dst = bv2 + key_pos_wb * dim;
+      }
+      __pipeline_wait_prior(1);
+      CopyValue::lds_stg(rank, dst, src, dim);
+      if (rank == GROUP_SIZE - 2) {
+        K* target_keys_ptr =
+            (target_bucket == 1) ? bucket_keys_ptr1 : bucket_keys_ptr2;
+        auto key_address = BUCKET::keys(target_keys_ptr, key_pos);
+        key_address->store(key, cuda::std::memory_order_release);
+      }
+    }
+  }
+
+  // Step 4 for last key (GROUP_SIZE - 1).
+  {
+    auto occupy_result_wb = g.shfl(occupy_result, GROUP_SIZE - 1);
+    if (occupy_result_wb != OccupyResult::ILLEGAL &&
+        occupy_result_wb != OccupyResult::REFUSED) {
+      VecV* src =
+          SMM::values_buffer(smem, groupID, same_buf(GROUP_SIZE + 1), dim);
+      auto key_pos_wb = g.shfl(key_pos, GROUP_SIZE - 1);
+      auto target_bucket_wb = g.shfl(target_bucket, GROUP_SIZE - 1);
+      VecV* dst;
+      if (target_bucket_wb == 1) {
+        VecV** sm_bucket_values_ptr = SMM::bucket_values_ptr(smem);
+        dst = sm_bucket_values_ptr[groupID * GROUP_SIZE + GROUP_SIZE - 1] +
+              key_pos_wb * dim;
+      } else {
+        auto bv2 = g.shfl(bucket_values_ptr2, GROUP_SIZE - 1);
+        dst = bv2 + key_pos_wb * dim;
+      }
+      __pipeline_wait_prior(0);
+      CopyValue::lds_stg(rank, dst, src, dim);
+      if (rank == GROUP_SIZE - 1) {
+        K* target_keys_ptr =
+            (target_bucket == 1) ? bucket_keys_ptr1 : bucket_keys_ptr2;
+        auto key_address = BUCKET::keys(target_keys_ptr, key_pos);
+        key_address->store(key, cuda::std::memory_order_release);
+      }
+    }
+  }
+}
+
+// --- Kernel Launcher ---
+
+template <typename K, typename V, typename S, typename VecV, int Strategy>
+struct Launch_DualBucket_Pipeline_Upsert {
+  using Params = Params_Upsert<K, V, S>;
+  inline static void launch_kernel(Params& params, cudaStream_t& stream) {
+    constexpr int BLOCK_SIZE = 128;
+    constexpr uint32_t GROUP_SIZE = 32;
+    constexpr uint32_t BUCKET_SIZE = 128;
+    using SMM = SharedMemoryManager_Pipeline_Upsert<K, V, S, VecV, BLOCK_SIZE,
+                                                    GROUP_SIZE, BUCKET_SIZE>;
+
+    params.dim = params.dim * sizeof(V) / sizeof(VecV);
+    uint32_t shared_mem = SMM::total_size(params.dim);
+    shared_mem =
+        (shared_mem + sizeof(byte16) - 1) / sizeof(byte16) * sizeof(byte16);
+    dual_bucket_pipeline_upsert_kernel_with_io<K, V, S, VecV, BLOCK_SIZE,
+                                               Strategy>
+        <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, shared_mem,
+           stream>>>(params.buckets, params.buckets_size, params.buckets_num,
+                     params.dim, params.keys,
+                     reinterpret_cast<const VecV*>(params.values),
+                     params.scores, params.n, params.global_epoch);
+  }
+};
+
+// --- Kernel Selector ---
+
+template <typename K, typename V, typename S, int Strategy, typename ArchTag>
+struct KernelSelector_DualBucketUpsert {
+  using Params = Params_Upsert<K, V, S>;
+
+  static void select_kernel(Params& params, cudaStream_t& stream) {
+    const uint32_t total_value_size =
+        static_cast<uint32_t>(params.dim * sizeof(V));
+
+    // Dual-bucket always uses pipeline kernel (optimized for bucket_size=128).
+    if (total_value_size % sizeof(byte16) == 0) {
+      using VecV = byte16;
+      Launch_DualBucket_Pipeline_Upsert<K, V, S, VecV, Strategy>::launch_kernel(
+          params, stream);
+    } else if (total_value_size % sizeof(byte8) == 0) {
+      using VecV = byte8;
+      Launch_DualBucket_Pipeline_Upsert<K, V, S, VecV, Strategy>::launch_kernel(
+          params, stream);
+    } else if (total_value_size % sizeof(byte4) == 0) {
+      using VecV = byte4;
+      Launch_DualBucket_Pipeline_Upsert<K, V, S, VecV, Strategy>::launch_kernel(
+          params, stream);
+    } else if (total_value_size % sizeof(byte2) == 0) {
+      using VecV = byte2;
+      Launch_DualBucket_Pipeline_Upsert<K, V, S, VecV, Strategy>::launch_kernel(
+          params, stream);
+    } else {
+      using VecV = byte;
+      Launch_DualBucket_Pipeline_Upsert<K, V, S, VecV, Strategy>::launch_kernel(
+          params, stream);
+    }
+  }
+};
+
+}  // namespace merlin
+}  // namespace nv

--- a/include/merlin/core_kernels/dual_bucket_utils.cuh
+++ b/include/merlin/core_kernels/dual_bucket_utils.cuh
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "kernel_utils.cuh"
+
+namespace nv {
+namespace merlin {
+
+/**
+ * Core dual-bucket index computation from a pre-computed hash.
+ * b1 = low 32 bits mod buckets_num, b2 = high 32 bits mod buckets_num.
+ * Guarantees b2 != b1 by advancing b2 on collision.
+ *
+ * This is the single source of truth for dual-bucket addressing.
+ * All kernels (upsert, lookup, etc.) must use this function.
+ */
+template <class K>
+__device__ __forceinline__ void get_dual_bucket_indices(
+    const K hashed_key, const size_t buckets_num, size_t& bkt_idx1,
+    size_t& bkt_idx2) {
+  const uint32_t lo = static_cast<uint32_t>(hashed_key);
+  const uint32_t hi =
+      static_cast<uint32_t>(static_cast<uint64_t>(hashed_key) >> 32);
+
+  bkt_idx1 = lo % buckets_num;
+  bkt_idx2 = hi % buckets_num;
+  if (bkt_idx2 == bkt_idx1) {
+    bkt_idx2 = (bkt_idx2 + 1) % buckets_num;
+  }
+}
+
+/**
+ * Digest extraction for dual-bucket mode.
+ * Uses bit[56:63] (highest 8 bits) of the hash to avoid collision
+ * with b2 addressing (which uses high 32 bits' low log2(buckets_num) bits).
+ */
+template <class K>
+__device__ __forceinline__ D get_dual_bucket_digest(const K& key) {
+  const K hashed_key = Murmur3HashDevice(key);
+  return static_cast<D>(static_cast<uint64_t>(hashed_key) >> 56);
+}
+
+/**
+ * Digest extraction from pre-computed hash for dual-bucket mode.
+ */
+template <class K>
+__device__ __forceinline__ D
+get_dual_bucket_digest_from_hash(const K& hashed_key) {
+  return static_cast<D>(static_cast<uint64_t>(hashed_key) >> 56);
+}
+
+/**
+ * Get vector of digests for SIMD comparison in dual-bucket mode.
+ */
+template <class K>
+__device__ __forceinline__ VecD_Comp
+dual_bucket_digests_from_hashed(const K& hashed_key) {
+  D digest = static_cast<D>(static_cast<uint64_t>(hashed_key) >> 56);
+  return static_cast<VecD_Comp>(__byte_perm(digest, digest, 0x0000));
+}
+
+/**
+ * Empty digest value for dual-bucket mode (bit[56:63] of hash(EMPTY_KEY)).
+ */
+template <class K>
+__device__ __forceinline__ D dual_bucket_empty_digest() {
+  const K hashed_key = Murmur3HashDevice(static_cast<K>(EMPTY_KEY));
+  return static_cast<D>(static_cast<uint64_t>(hashed_key) >> 56);
+}
+
+/**
+ * Empty digests vector for dual-bucket SIMD comparison.
+ */
+template <class K>
+__device__ __forceinline__ VecD_Comp dual_bucket_empty_digests() {
+  D digest = dual_bucket_empty_digest<K>();
+  return static_cast<VecD_Comp>(__byte_perm(digest, digest, 0x0000));
+}
+
+}  // namespace merlin
+}  // namespace nv

--- a/include/merlin/types.cuh
+++ b/include/merlin/types.cuh
@@ -212,6 +212,7 @@ struct Table {
                                          // HBM allocation, must be power of 2.
   bool is_pure_hbm = true;               // unused
   bool primary = true;                   // unused
+  bool dual_bucket_mode = false;         // Enable dual-bucket addressing
   int slots_offset = 0;                  // unused
   int slots_number = 0;                  // unused
   int device_id = 0;                     // Device id

--- a/tests/dual_bucket_test.cc.cu
+++ b/tests/dual_bucket_test.cc.cu
@@ -1,0 +1,1930 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <algorithm>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <unordered_set>
+#include <vector>
+#include "merlin_hashtable.cuh"
+#include "test_util.cuh"
+
+constexpr size_t DIM = 16;
+using K = uint64_t;
+using V = float;
+using S = uint64_t;
+using TableOptions = nv::merlin::HashTableOptions;
+using TableMode = nv::merlin::TableMode;
+using EvictStrategy = nv::merlin::EvictStrategy;
+
+/*
+ * Helper: create a MEMORY_MODE table with fixed capacity.
+ */
+template <typename Table>
+void create_memory_mode_table(Table& table, size_t capacity, size_t dim = DIM) {
+  TableOptions options;
+  options.init_capacity = capacity;
+  options.max_capacity = capacity;
+  options.max_hbm_for_vectors = 0;
+  options.dim = dim;
+  options.max_bucket_size = 128;
+  options.table_mode = TableMode::kMemory;
+  table.init(options);
+}
+
+/*
+ * Helper: create a THROUGHPUT_MODE table with fixed capacity.
+ */
+template <typename Table>
+void create_throughput_mode_table(Table& table, size_t capacity,
+                                  size_t dim = DIM) {
+  TableOptions options;
+  options.init_capacity = capacity;
+  options.max_capacity = capacity;
+  options.max_hbm_for_vectors = 0;
+  options.dim = dim;
+  options.max_bucket_size = 128;
+  options.table_mode = TableMode::kThroughput;
+  table.init(options);
+}
+
+// ==============================
+// TestGroup 1: Basic Correctness
+// ==============================
+
+// T1.1: MEMORY_MODE insert_or_assign + find basic functionality.
+TEST(DualBucketTest, BasicInsertAndFind) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+  constexpr size_t CAPACITY = 128 * 1024;  // ~16K entries
+  constexpr size_t N = static_cast<size_t>(CAPACITY * 0.5);
+
+  Table table;
+  create_memory_mode_table(table, CAPACITY);
+
+  // Allocate host data.
+  std::vector<K> h_keys(N);
+  std::vector<V> h_values(N * DIM);
+  std::vector<S> h_scores(N);
+
+  std::iota(h_keys.begin(), h_keys.end(), 1);
+  for (size_t i = 0; i < N; i++) {
+    h_scores[i] = i + 1;
+    for (size_t j = 0; j < DIM; j++) {
+      h_values[i * DIM + j] = static_cast<V>(h_keys[i] * 0.00001f);
+    }
+  }
+
+  // Allocate device data.
+  K* d_keys;
+  V* d_values;
+  S* d_scores;
+  bool* d_founds;
+  V* d_found_values;
+
+  CUDA_CHECK(cudaMalloc(&d_keys, N * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, N * DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_scores, N * sizeof(S)));
+  CUDA_CHECK(cudaMalloc(&d_founds, N * sizeof(bool)));
+  CUDA_CHECK(cudaMalloc(&d_found_values, N * DIM * sizeof(V)));
+
+  CUDA_CHECK(
+      cudaMemcpy(d_keys, h_keys.data(), N * sizeof(K), cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_values, h_values.data(), N * DIM * sizeof(V),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_scores, h_scores.data(), N * sizeof(S),
+                        cudaMemcpyHostToDevice));
+
+  // Insert.
+  table.insert_or_assign(N, d_keys, d_values, d_scores, /*stream=*/0,
+                         /*unique_key=*/true);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  // Verify size.
+  size_t table_size = table.size(/*stream=*/0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+  EXPECT_EQ(table_size, N);
+
+  // Find.
+  table.find(N, d_keys, d_found_values, d_founds, /*scores=*/nullptr,
+             /*stream=*/0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  // Check all found.
+  bool* h_founds = new bool[N];
+  CUDA_CHECK(
+      cudaMemcpy(h_founds, d_founds, N * sizeof(bool), cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < N; i++) {
+    EXPECT_TRUE(h_founds[i]) << "Key " << h_keys[i] << " not found";
+  }
+
+  // Check values correct.
+  std::vector<V> h_found_values(N * DIM);
+  CUDA_CHECK(cudaMemcpy(h_found_values.data(), d_found_values,
+                        N * DIM * sizeof(V), cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < N; i++) {
+    for (size_t j = 0; j < DIM; j++) {
+      EXPECT_FLOAT_EQ(h_found_values[i * DIM + j],
+                      static_cast<V>(h_keys[i] * 0.00001f))
+          << "Value mismatch for key " << h_keys[i] << " dim " << j;
+    }
+  }
+
+  delete[] h_founds;
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+  CUDA_CHECK(cudaFree(d_scores));
+  CUDA_CHECK(cudaFree(d_founds));
+  CUDA_CHECK(cudaFree(d_found_values));
+}
+
+// T1.2: MEMORY_MODE assign (update) - key already exists.
+TEST(DualBucketTest, UpdateExistingKey) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+  constexpr size_t CAPACITY = 128 * 1024;
+  constexpr size_t N = 1024;
+
+  Table table;
+  create_memory_mode_table(table, CAPACITY);
+
+  std::vector<K> h_keys(N);
+  std::vector<V> h_values_v1(N * DIM);
+  std::vector<V> h_values_v2(N * DIM);
+  std::vector<S> h_scores(N);
+
+  std::iota(h_keys.begin(), h_keys.end(), 1);
+  for (size_t i = 0; i < N; i++) {
+    h_scores[i] = i + 1;
+    for (size_t j = 0; j < DIM; j++) {
+      h_values_v1[i * DIM + j] = 1.0f;
+      h_values_v2[i * DIM + j] = 2.0f;
+    }
+  }
+
+  K* d_keys;
+  V* d_values;
+  S* d_scores;
+  bool* d_founds;
+  V* d_found_values;
+
+  CUDA_CHECK(cudaMalloc(&d_keys, N * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, N * DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_scores, N * sizeof(S)));
+  CUDA_CHECK(cudaMalloc(&d_founds, N * sizeof(bool)));
+  CUDA_CHECK(cudaMalloc(&d_found_values, N * DIM * sizeof(V)));
+
+  CUDA_CHECK(
+      cudaMemcpy(d_keys, h_keys.data(), N * sizeof(K), cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_scores, h_scores.data(), N * sizeof(S),
+                        cudaMemcpyHostToDevice));
+
+  // Insert V1.
+  CUDA_CHECK(cudaMemcpy(d_values, h_values_v1.data(), N * DIM * sizeof(V),
+                        cudaMemcpyHostToDevice));
+  table.insert_or_assign(N, d_keys, d_values, d_scores, 0, true);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  // Update with V2.
+  CUDA_CHECK(cudaMemcpy(d_values, h_values_v2.data(), N * DIM * sizeof(V),
+                        cudaMemcpyHostToDevice));
+  table.insert_or_assign(N, d_keys, d_values, d_scores, 0, true);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  // Size should still be N (no duplicates).
+  size_t table_size = table.size(0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+  EXPECT_EQ(table_size, N);
+
+  // Find and verify V2 values.
+  table.find(N, d_keys, d_found_values, d_founds, nullptr, 0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  std::vector<V> h_found_values(N * DIM);
+  CUDA_CHECK(cudaMemcpy(h_found_values.data(), d_found_values,
+                        N * DIM * sizeof(V), cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < N; i++) {
+    for (size_t j = 0; j < DIM; j++) {
+      EXPECT_FLOAT_EQ(h_found_values[i * DIM + j], 2.0f)
+          << "Expected V2 value for key " << h_keys[i] << " dim " << j;
+    }
+  }
+
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+  CUDA_CHECK(cudaFree(d_scores));
+  CUDA_CHECK(cudaFree(d_founds));
+  CUDA_CHECK(cudaFree(d_found_values));
+}
+
+// T1.3: MEMORY_MODE score-eviction correctness.
+TEST(DualBucketTest, ScoreEviction) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+  // Small capacity to force eviction quickly.
+  constexpr size_t CAPACITY = 128 * 128;  // 128 buckets * 128 slots = 16384
+  constexpr size_t N_FILL = CAPACITY;     // Fill completely
+  constexpr size_t N_NEW = 1024;          // Insert high-score keys
+
+  Table table;
+  create_memory_mode_table(table, CAPACITY);
+
+  // Phase 1: Fill table with low-score keys.
+  std::vector<K> h_keys_fill(N_FILL);
+  std::vector<V> h_values_fill(N_FILL * DIM, 1.0f);
+  std::vector<S> h_scores_fill(N_FILL);
+
+  std::iota(h_keys_fill.begin(), h_keys_fill.end(), 1);
+  for (size_t i = 0; i < N_FILL; i++) {
+    h_scores_fill[i] = i + 1;  // Low scores: 1..N_FILL
+  }
+
+  K* d_keys;
+  V* d_values;
+  S* d_scores;
+  CUDA_CHECK(cudaMalloc(&d_keys, N_FILL * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, N_FILL * DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_scores, N_FILL * sizeof(S)));
+
+  CUDA_CHECK(cudaMemcpy(d_keys, h_keys_fill.data(), N_FILL * sizeof(K),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_values, h_values_fill.data(),
+                        N_FILL * DIM * sizeof(V), cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_scores, h_scores_fill.data(), N_FILL * sizeof(S),
+                        cudaMemcpyHostToDevice));
+
+  table.insert_or_assign(N_FILL, d_keys, d_values, d_scores, 0, true);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  // Phase 2: Insert high-score keys (should evict low-score keys).
+  std::vector<K> h_keys_new(N_NEW);
+  std::vector<V> h_values_new(N_NEW * DIM, 2.0f);
+  std::vector<S> h_scores_new(N_NEW);
+
+  for (size_t i = 0; i < N_NEW; i++) {
+    h_keys_new[i] = N_FILL + 1 + i;       // New keys
+    h_scores_new[i] = N_FILL + 1000 + i;  // High scores
+  }
+
+  CUDA_CHECK(cudaMemcpy(d_keys, h_keys_new.data(), N_NEW * sizeof(K),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_values, h_values_new.data(), N_NEW * DIM * sizeof(V),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_scores, h_scores_new.data(), N_NEW * sizeof(S),
+                        cudaMemcpyHostToDevice));
+
+  table.insert_or_assign(N_NEW, d_keys, d_values, d_scores, 0, true);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  // Phase 3: Verify high-score keys are present.
+  bool* d_founds;
+  V* d_found_values;
+  CUDA_CHECK(cudaMalloc(&d_founds, N_NEW * sizeof(bool)));
+  CUDA_CHECK(cudaMalloc(&d_found_values, N_NEW * DIM * sizeof(V)));
+
+  CUDA_CHECK(cudaMemcpy(d_keys, h_keys_new.data(), N_NEW * sizeof(K),
+                        cudaMemcpyHostToDevice));
+  table.find(N_NEW, d_keys, d_found_values, d_founds, nullptr, 0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  bool* h_founds = new bool[N_NEW];
+  CUDA_CHECK(cudaMemcpy(h_founds, d_founds, N_NEW * sizeof(bool),
+                        cudaMemcpyDeviceToHost));
+
+  int found_count = 0;
+  for (size_t i = 0; i < N_NEW; i++) {
+    if (h_founds[i]) found_count++;
+  }
+  std::cout << "[ScoreEviction] High-score keys accuracy: " << found_count
+            << "/" << N_NEW << " (" << (100.0 * found_count / N_NEW) << "%)"
+            << std::endl;
+  // Most high-score keys should be found.  Require >= 80%.
+  EXPECT_GT(found_count, static_cast<int>(N_NEW * 0.8))
+      << "Expected >= 80% of high-score keys to survive eviction";
+
+  delete[] h_founds;
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+  CUDA_CHECK(cudaFree(d_scores));
+  CUDA_CHECK(cudaFree(d_founds));
+  CUDA_CHECK(cudaFree(d_found_values));
+}
+
+// T1.4: THROUGHPUT_MODE regression test (not affected by dual-bucket changes).
+TEST(DualBucketTest, ThroughputModeRegression) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+  constexpr size_t CAPACITY = 128 * 1024;
+  constexpr size_t N = 4096;
+
+  Table table;
+  create_throughput_mode_table(table, CAPACITY);
+
+  std::vector<K> h_keys(N);
+  std::vector<V> h_values(N * DIM);
+  std::vector<S> h_scores(N);
+
+  std::iota(h_keys.begin(), h_keys.end(), 1);
+  for (size_t i = 0; i < N; i++) {
+    h_scores[i] = i + 1;
+    for (size_t j = 0; j < DIM; j++) {
+      h_values[i * DIM + j] = static_cast<V>(h_keys[i] * 0.001f);
+    }
+  }
+
+  K* d_keys;
+  V* d_values;
+  S* d_scores;
+  bool* d_founds;
+  V* d_found_values;
+
+  CUDA_CHECK(cudaMalloc(&d_keys, N * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, N * DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_scores, N * sizeof(S)));
+  CUDA_CHECK(cudaMalloc(&d_founds, N * sizeof(bool)));
+  CUDA_CHECK(cudaMalloc(&d_found_values, N * DIM * sizeof(V)));
+
+  CUDA_CHECK(
+      cudaMemcpy(d_keys, h_keys.data(), N * sizeof(K), cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_values, h_values.data(), N * DIM * sizeof(V),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_scores, h_scores.data(), N * sizeof(S),
+                        cudaMemcpyHostToDevice));
+
+  table.insert_or_assign(N, d_keys, d_values, d_scores, 0, true);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  table.find(N, d_keys, d_found_values, d_founds, nullptr, 0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  bool* h_founds = new bool[N];
+  CUDA_CHECK(
+      cudaMemcpy(h_founds, d_founds, N * sizeof(bool), cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < N; i++) {
+    EXPECT_TRUE(h_founds[i])
+        << "THROUGHPUT_MODE: Key " << h_keys[i] << " not found";
+  }
+
+  delete[] h_founds;
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+  CUDA_CHECK(cudaFree(d_scores));
+  CUDA_CHECK(cudaFree(d_founds));
+  CUDA_CHECK(cudaFree(d_found_values));
+}
+
+// ==========================================
+// TestGroup 2: Dual-bucket Feature Verify
+// ==========================================
+
+// T2.2: First eviction load factor comparison.
+TEST(DualBucketTest, FirstEvictionLoadFactor) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+  constexpr size_t CAPACITY = 10 * 1024 * 1024;  // ~10M slots
+
+  // Run for MEMORY_MODE.
+  {
+    Table table;
+    create_memory_mode_table(table, CAPACITY);
+
+    constexpr size_t BATCH = 128;
+    std::vector<K> h_keys(BATCH);
+    std::vector<V> h_values(BATCH * DIM, 1.0f);
+    std::vector<S> h_scores(BATCH);
+
+    K* d_keys;
+    V* d_values;
+    S* d_scores;
+    CUDA_CHECK(cudaMalloc(&d_keys, BATCH * sizeof(K)));
+    CUDA_CHECK(cudaMalloc(&d_values, BATCH * DIM * sizeof(V)));
+    CUDA_CHECK(cudaMalloc(&d_scores, BATCH * sizeof(S)));
+
+    K next_key = 1;
+    size_t total_inserted = 0;
+    float first_eviction_lf = 0.0f;
+
+    // Insert in batches until table is nearly full.
+    while (total_inserted < CAPACITY) {
+      for (size_t i = 0; i < BATCH; i++) {
+        h_keys[i] = next_key++;
+        h_scores[i] = h_keys[i];  // Score = key value (ascending)
+      }
+      CUDA_CHECK(cudaMemcpy(d_keys, h_keys.data(), BATCH * sizeof(K),
+                            cudaMemcpyHostToDevice));
+      CUDA_CHECK(cudaMemcpy(d_values, h_values.data(), BATCH * DIM * sizeof(V),
+                            cudaMemcpyHostToDevice));
+      CUDA_CHECK(cudaMemcpy(d_scores, h_scores.data(), BATCH * sizeof(S),
+                            cudaMemcpyHostToDevice));
+
+      table.insert_or_assign(BATCH, d_keys, d_values, d_scores, 0, true);
+      CUDA_CHECK(cudaDeviceSynchronize());
+      total_inserted += BATCH;
+
+      size_t table_size = table.size(0);
+      CUDA_CHECK(cudaDeviceSynchronize());
+
+      // If table_size < total_inserted, eviction occurred.
+      if (table_size < total_inserted && first_eviction_lf == 0.0f) {
+        first_eviction_lf =
+            static_cast<float>(table_size) / static_cast<float>(CAPACITY);
+        break;
+      }
+    }
+
+    std::cout << "[MEMORY_MODE] First eviction LF: " << first_eviction_lf
+              << " (total_inserted=" << total_inserted << ")" << std::endl;
+
+    // Dual-bucket two-choice hashing should achieve very high LF before first
+    // eviction.  Empirically measured ~0.982 at 10M scale on A6000.
+    EXPECT_GT(first_eviction_lf, 0.980f)
+        << "Dual-bucket should delay eviction beyond 98.0% LF";
+
+    CUDA_CHECK(cudaFree(d_keys));
+    CUDA_CHECK(cudaFree(d_values));
+    CUDA_CHECK(cudaFree(d_scores));
+  }
+}
+
+// ===================================
+// TestGroup 3: API Guard Tests
+// ===================================
+
+TEST(DualBucketTest, EraseGuard) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+  Table table;
+  create_memory_mode_table(table, 128 * 128);
+
+  K* d_keys;
+  CUDA_CHECK(cudaMalloc(&d_keys, sizeof(K)));
+  K h_key = 1;
+  CUDA_CHECK(cudaMemcpy(d_keys, &h_key, sizeof(K), cudaMemcpyHostToDevice));
+
+  EXPECT_THROW(table.erase(1, d_keys, 0), std::runtime_error);
+
+  CUDA_CHECK(cudaFree(d_keys));
+}
+
+TEST(DualBucketTest, ContainsGuard) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+  Table table;
+  create_memory_mode_table(table, 128 * 128);
+
+  K* d_keys;
+  bool* d_founds;
+  CUDA_CHECK(cudaMalloc(&d_keys, sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_founds, sizeof(bool)));
+  K h_key = 1;
+  CUDA_CHECK(cudaMemcpy(d_keys, &h_key, sizeof(K), cudaMemcpyHostToDevice));
+
+  EXPECT_THROW(table.contains(1, d_keys, d_founds, 0), std::runtime_error);
+
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_founds));
+}
+
+TEST(DualBucketTest, ReserveGuard) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+  Table table;
+  create_memory_mode_table(table, 128 * 128);
+
+  EXPECT_THROW(table.reserve(128 * 256, 0), std::runtime_error);
+}
+
+// ===================================
+// TestGroup 4: Boundary Conditions
+// ===================================
+
+// T4.1: Empty table find.
+TEST(DualBucketTest, EmptyTableFind) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+  Table table;
+  create_memory_mode_table(table, 128 * 128);
+
+  constexpr size_t N = 64;
+  K* d_keys;
+  V* d_values;
+  bool* d_founds;
+  CUDA_CHECK(cudaMalloc(&d_keys, N * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, N * DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_founds, N * sizeof(bool)));
+
+  std::vector<K> h_keys(N);
+  std::iota(h_keys.begin(), h_keys.end(), 1);
+  CUDA_CHECK(
+      cudaMemcpy(d_keys, h_keys.data(), N * sizeof(K), cudaMemcpyHostToDevice));
+
+  table.find(N, d_keys, d_values, d_founds, nullptr, 0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  bool* h_founds = new bool[N];
+  CUDA_CHECK(
+      cudaMemcpy(h_founds, d_founds, N * sizeof(bool), cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < N; i++) {
+    EXPECT_FALSE(h_founds[i])
+        << "Empty table should not find key " << h_keys[i];
+  }
+
+  delete[] h_founds;
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+  CUDA_CHECK(cudaFree(d_founds));
+}
+
+// T4.4: Different dim values.
+TEST(DualBucketTest, DimVariation) {
+  using Table1 = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+  // Test dim=1 and dim=64 (exercises different VecV specializations).
+  // Note: dim > 224 exceeds the dual-bucket lookup kernel's fixed shared-memory
+  // buffer (896 bytes).  init() now rejects dim > 224 for kMemory mode.
+  for (size_t test_dim : {1, 64}) {
+    Table1 table;
+    constexpr size_t CAPACITY = 128 * 128;
+    constexpr size_t N = 256;
+
+    TableOptions options;
+    options.init_capacity = CAPACITY;
+    options.max_capacity = CAPACITY;
+    options.max_hbm_for_vectors = 0;
+    options.dim = test_dim;
+    options.max_bucket_size = 128;
+    options.table_mode = TableMode::kMemory;
+    table.init(options);
+
+    std::vector<K> h_keys(N);
+    std::vector<V> h_values(N * test_dim);
+    std::vector<S> h_scores(N);
+
+    std::iota(h_keys.begin(), h_keys.end(), 1);
+    for (size_t i = 0; i < N; i++) {
+      h_scores[i] = i + 1;
+      for (size_t j = 0; j < test_dim; j++) {
+        h_values[i * test_dim + j] = static_cast<V>(i);
+      }
+    }
+
+    K* d_keys;
+    V* d_values;
+    S* d_scores;
+    bool* d_founds;
+    V* d_found_values;
+    CUDA_CHECK(cudaMalloc(&d_keys, N * sizeof(K)));
+    CUDA_CHECK(cudaMalloc(&d_values, N * test_dim * sizeof(V)));
+    CUDA_CHECK(cudaMalloc(&d_scores, N * sizeof(S)));
+    CUDA_CHECK(cudaMalloc(&d_founds, N * sizeof(bool)));
+    CUDA_CHECK(cudaMalloc(&d_found_values, N * test_dim * sizeof(V)));
+
+    CUDA_CHECK(cudaMemcpy(d_keys, h_keys.data(), N * sizeof(K),
+                          cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_values, h_values.data(), N * test_dim * sizeof(V),
+                          cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_scores, h_scores.data(), N * sizeof(S),
+                          cudaMemcpyHostToDevice));
+
+    table.insert_or_assign(N, d_keys, d_values, d_scores, 0, true);
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+    table.find(N, d_keys, d_found_values, d_founds, nullptr, 0);
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+    bool* h_founds = new bool[N];
+    CUDA_CHECK(cudaMemcpy(h_founds, d_founds, N * sizeof(bool),
+                          cudaMemcpyDeviceToHost));
+    std::vector<V> h_found_values(N * test_dim);
+    CUDA_CHECK(cudaMemcpy(h_found_values.data(), d_found_values,
+                          N * test_dim * sizeof(V), cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < N; i++) {
+      EXPECT_TRUE(h_founds[i])
+          << "dim=" << test_dim << ": Key " << h_keys[i] << " not found";
+      if (h_founds[i]) {
+        for (size_t j = 0; j < test_dim; j++) {
+          EXPECT_FLOAT_EQ(h_found_values[i * test_dim + j], static_cast<V>(i))
+              << "dim=" << test_dim << ": Value mismatch key " << h_keys[i]
+              << " dim " << j;
+        }
+      }
+    }
+
+    delete[] h_founds;
+    CUDA_CHECK(cudaFree(d_keys));
+    CUDA_CHECK(cudaFree(d_values));
+    CUDA_CHECK(cudaFree(d_scores));
+    CUDA_CHECK(cudaFree(d_founds));
+    CUDA_CHECK(cudaFree(d_found_values));
+  }
+}
+
+// ===================================
+// TestGroup 5: Init Validation
+// ===================================
+
+TEST(DualBucketTest, InitCapacityMismatchReject) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+  Table table;
+
+  TableOptions options;
+  options.init_capacity = 128 * 128;
+  options.max_capacity = 128 * 256;  // Different from init_capacity!
+  options.max_hbm_for_vectors = 0;
+  options.dim = DIM;
+  options.max_bucket_size = 128;
+  options.table_mode = TableMode::kMemory;
+
+  EXPECT_THROW(table.init(options), std::runtime_error);
+}
+
+// ===================================
+// TestGroup 2 additions
+// ===================================
+
+// T2.3: b1 == b2 degeneration.
+// When a key's two bucket indices collide, the kernel must degenerate to
+// single-bucket behaviour without data corruption or deadlock.
+TEST(DualBucketTest, B1EqualsB2Degeneration) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+  // Use a small number of buckets so that collisions of lo%N == hi%N are
+  // reasonably frequent.  With 4 buckets the probability for each key is ~25%.
+  constexpr size_t NUM_BUCKETS = 4;
+  constexpr size_t CAPACITY = NUM_BUCKETS * 128;  // 512 slots
+  constexpr size_t N = 256;
+
+  Table table;
+  create_memory_mode_table(table, CAPACITY);
+
+  std::vector<K> h_keys(N);
+  std::vector<V> h_values(N * DIM);
+  std::vector<S> h_scores(N);
+
+  std::iota(h_keys.begin(), h_keys.end(), 1);
+  for (size_t i = 0; i < N; i++) {
+    h_scores[i] = i + 1;
+    for (size_t j = 0; j < DIM; j++)
+      h_values[i * DIM + j] = static_cast<V>(h_keys[i]);
+  }
+
+  K* d_keys;
+  V* d_values;
+  S* d_scores;
+  bool* d_founds;
+  V* d_found_values;
+  CUDA_CHECK(cudaMalloc(&d_keys, N * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, N * DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_scores, N * sizeof(S)));
+  CUDA_CHECK(cudaMalloc(&d_founds, N * sizeof(bool)));
+  CUDA_CHECK(cudaMalloc(&d_found_values, N * DIM * sizeof(V)));
+
+  CUDA_CHECK(
+      cudaMemcpy(d_keys, h_keys.data(), N * sizeof(K), cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_values, h_values.data(), N * DIM * sizeof(V),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_scores, h_scores.data(), N * sizeof(S),
+                        cudaMemcpyHostToDevice));
+
+  table.insert_or_assign(N, d_keys, d_values, d_scores, 0, true);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  // All N keys should be found, regardless of b1==b2 collisions.
+  table.find(N, d_keys, d_found_values, d_founds, nullptr, 0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  bool* h_founds = new bool[N];
+  CUDA_CHECK(
+      cudaMemcpy(h_founds, d_founds, N * sizeof(bool), cudaMemcpyDeviceToHost));
+  std::vector<V> h_found_values(N * DIM);
+  CUDA_CHECK(cudaMemcpy(h_found_values.data(), d_found_values,
+                        N * DIM * sizeof(V), cudaMemcpyDeviceToHost));
+
+  for (size_t i = 0; i < N; i++) {
+    EXPECT_TRUE(h_founds[i]) << "Key " << h_keys[i] << " not found (b1==b2?)";
+    if (h_founds[i]) {
+      EXPECT_FLOAT_EQ(h_found_values[i * DIM], static_cast<V>(h_keys[i]))
+          << "Value mismatch for key " << h_keys[i];
+    }
+  }
+
+  // Table size must equal N (no duplicates from b1==b2 path).
+  size_t table_size = table.size(0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+  EXPECT_EQ(table_size, N);
+
+  delete[] h_founds;
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+  CUDA_CHECK(cudaFree(d_scores));
+  CUDA_CHECK(cudaFree(d_founds));
+  CUDA_CHECK(cudaFree(d_found_values));
+}
+
+// T2.5: Digest effectiveness — verify that dual-bucket digest (bit[56:63])
+// is used consistently during init, insert, and find.  If the init kernel
+// wrote the wrong empty-digest value, empty-slot detection would fail and
+// no keys could be inserted.  This test therefore doubles as a regression
+// guard for the G1 digest-mismatch bug.
+TEST(DualBucketTest, DigestEffectiveness) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+  constexpr size_t CAPACITY = 128 * 64;  // 8192 slots, 64 buckets
+  constexpr size_t N = 4096;             // 50% LF
+
+  Table table;
+  create_memory_mode_table(table, CAPACITY);
+
+  std::vector<K> h_keys(N);
+  std::vector<V> h_values(N * DIM, 1.0f);
+  std::vector<S> h_scores(N);
+
+  // Use random keys so that digests are well-distributed.
+  std::mt19937_64 rng(42);
+  for (size_t i = 0; i < N; i++) {
+    h_keys[i] = (rng() & 0x00FFFFFFFFFFFFFF) | 1;  // avoid reserved keys
+    h_scores[i] = i + 1;
+  }
+
+  K* d_keys;
+  V* d_values;
+  S* d_scores;
+  bool* d_founds;
+  V* d_found_values;
+  CUDA_CHECK(cudaMalloc(&d_keys, N * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, N * DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_scores, N * sizeof(S)));
+  CUDA_CHECK(cudaMalloc(&d_founds, N * sizeof(bool)));
+  CUDA_CHECK(cudaMalloc(&d_found_values, N * DIM * sizeof(V)));
+
+  CUDA_CHECK(
+      cudaMemcpy(d_keys, h_keys.data(), N * sizeof(K), cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_values, h_values.data(), N * DIM * sizeof(V),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_scores, h_scores.data(), N * sizeof(S),
+                        cudaMemcpyHostToDevice));
+
+  table.insert_or_assign(N, d_keys, d_values, d_scores, 0, true);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  // If empty-digest was wrong, insert would have gone through the D2 eviction
+  // path and all entries would be REFUSED.  Check that table is not empty.
+  size_t table_size = table.size(0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+  EXPECT_EQ(table_size, N) << "Digest mismatch: expected " << N
+                           << " entries but got " << table_size
+                           << " (empty-slot detection likely failed)";
+
+  // Verify every key is findable.
+  table.find(N, d_keys, d_found_values, d_founds, nullptr, 0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  bool* h_founds = new bool[N];
+  CUDA_CHECK(
+      cudaMemcpy(h_founds, d_founds, N * sizeof(bool), cudaMemcpyDeviceToHost));
+  int found_count = 0;
+  for (size_t i = 0; i < N; i++) {
+    if (h_founds[i]) found_count++;
+  }
+  EXPECT_EQ(found_count, static_cast<int>(N))
+      << "Digest mismatch on find: only " << found_count << "/" << N
+      << " keys found";
+
+  delete[] h_founds;
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+  CUDA_CHECK(cudaFree(d_scores));
+  CUDA_CHECK(cudaFree(d_founds));
+  CUDA_CHECK(cudaFree(d_found_values));
+}
+
+// ===================================
+// TestGroup 1 addition: Score ordering after eviction
+// ===================================
+
+// T1.3b: After eviction, surviving keys must have scores >= the scores of
+// evicted keys.  We export the full table and verify score ordering.
+TEST(DualBucketTest, ScoreOrderingAfterEviction) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+  constexpr size_t CAPACITY = 128 * 64;  // 8192 slots
+  constexpr size_t N_FILL = CAPACITY;
+  constexpr size_t N_NEW = 512;
+
+  Table table;
+  create_memory_mode_table(table, CAPACITY);
+
+  // Phase 1: Fill with scores [1..N_FILL].
+  std::vector<K> h_keys(N_FILL);
+  std::vector<V> h_values(N_FILL * DIM, 1.0f);
+  std::vector<S> h_scores(N_FILL);
+
+  std::iota(h_keys.begin(), h_keys.end(), 1);
+  for (size_t i = 0; i < N_FILL; i++) h_scores[i] = i + 1;
+
+  K* d_keys;
+  V* d_values;
+  S* d_scores;
+  CUDA_CHECK(cudaMalloc(&d_keys, N_FILL * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, N_FILL * DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_scores, N_FILL * sizeof(S)));
+
+  CUDA_CHECK(cudaMemcpy(d_keys, h_keys.data(), N_FILL * sizeof(K),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_values, h_values.data(), N_FILL * DIM * sizeof(V),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_scores, h_scores.data(), N_FILL * sizeof(S),
+                        cudaMemcpyHostToDevice));
+
+  table.insert_or_assign(N_FILL, d_keys, d_values, d_scores, 0, true);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  // Phase 2: Insert high-score keys that force eviction.
+  std::vector<K> h_keys_new(N_NEW);
+  std::vector<V> h_values_new(N_NEW * DIM, 2.0f);
+  std::vector<S> h_scores_new(N_NEW);
+  for (size_t i = 0; i < N_NEW; i++) {
+    h_keys_new[i] = N_FILL + 1 + i;
+    h_scores_new[i] = N_FILL * 10 + i;  // Much higher scores
+  }
+
+  CUDA_CHECK(cudaMemcpy(d_keys, h_keys_new.data(), N_NEW * sizeof(K),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_values, h_values_new.data(), N_NEW * DIM * sizeof(V),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_scores, h_scores_new.data(), N_NEW * sizeof(S),
+                        cudaMemcpyHostToDevice));
+
+  table.insert_or_assign(N_NEW, d_keys, d_values, d_scores, 0, true);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  // Phase 3: Export all surviving entries and check scores.
+  size_t table_size = table.size(0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  K* d_dump_keys;
+  V* d_dump_values;
+  S* d_dump_scores;
+  size_t* d_dump_counter;
+  CUDA_CHECK(cudaMalloc(&d_dump_keys, table_size * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_dump_values, table_size * DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_dump_scores, table_size * sizeof(S)));
+  CUDA_CHECK(cudaMalloc(&d_dump_counter, sizeof(size_t)));
+  CUDA_CHECK(cudaMemset(d_dump_counter, 0, sizeof(size_t)));
+
+  table.export_batch(table_size, 0, d_dump_counter, d_dump_keys, d_dump_values,
+                     d_dump_scores, 0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  size_t dumped;
+  CUDA_CHECK(cudaMemcpy(&dumped, d_dump_counter, sizeof(size_t),
+                        cudaMemcpyDeviceToHost));
+
+  std::vector<S> h_dump_scores(dumped);
+  CUDA_CHECK(cudaMemcpy(h_dump_scores.data(), d_dump_scores, dumped * sizeof(S),
+                        cudaMemcpyDeviceToHost));
+
+  // Find the minimum score among all surviving entries.
+  S min_surviving =
+      *std::min_element(h_dump_scores.begin(), h_dump_scores.end());
+
+  // Check that all high-score keys that were inserted have scores above
+  // the surviving minimum.  (Some high-score keys may have been REFUSED,
+  // but if they ARE in the table, their score must be consistent.)
+  std::vector<K> h_dump_keys(dumped);
+  CUDA_CHECK(cudaMemcpy(h_dump_keys.data(), d_dump_keys, dumped * sizeof(K),
+                        cudaMemcpyDeviceToHost));
+
+  int high_score_survivors = 0;
+  for (size_t i = 0; i < dumped; i++) {
+    if (h_dump_keys[i] > N_FILL) {
+      high_score_survivors++;
+      // Every high-score key should have score >= min_surviving.
+      EXPECT_GE(h_dump_scores[i], min_surviving);
+    }
+  }
+  // At least some high-score keys should have survived.
+  EXPECT_GT(high_score_survivors, 0) << "No high-score keys survived eviction";
+
+  std::cout << "[ScoreOrdering] min_surviving_score=" << min_surviving
+            << " high_score_survivors=" << high_score_survivors << "/" << N_NEW
+            << std::endl;
+
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+  CUDA_CHECK(cudaFree(d_scores));
+  CUDA_CHECK(cudaFree(d_dump_keys));
+  CUDA_CHECK(cudaFree(d_dump_values));
+  CUDA_CHECK(cudaFree(d_dump_scores));
+  CUDA_CHECK(cudaFree(d_dump_counter));
+}
+
+// ===================================
+// TestGroup 3 additions: API Guard Tests (new)
+// ===================================
+
+TEST(DualBucketTest, FindOrInsertGuard) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+  Table table;
+  create_memory_mode_table(table, 128 * 128);
+
+  K* d_keys;
+  V* d_values;
+  S* d_scores;
+  CUDA_CHECK(cudaMalloc(&d_keys, sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_scores, sizeof(S)));
+
+  EXPECT_THROW(table.find_or_insert(1, d_keys, d_values, d_scores, 0, true),
+               std::runtime_error);
+
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+  CUDA_CHECK(cudaFree(d_scores));
+}
+
+TEST(DualBucketTest, InsertAndEvictGuard) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+  Table table;
+  create_memory_mode_table(table, 128 * 128);
+
+  K* d_keys;
+  V* d_values;
+  S* d_scores;
+  K* d_evicted_keys;
+  V* d_evicted_values;
+  S* d_evicted_scores;
+  size_t* d_counter;
+  CUDA_CHECK(cudaMalloc(&d_keys, sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_scores, sizeof(S)));
+  CUDA_CHECK(cudaMalloc(&d_evicted_keys, sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_evicted_values, DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_evicted_scores, sizeof(S)));
+  CUDA_CHECK(cudaMalloc(&d_counter, sizeof(size_t)));
+
+  EXPECT_THROW(
+      table.insert_and_evict(1, d_keys, d_values, d_scores, d_evicted_keys,
+                             d_evicted_values, d_evicted_scores, d_counter, 0),
+      std::runtime_error);
+
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+  CUDA_CHECK(cudaFree(d_scores));
+  CUDA_CHECK(cudaFree(d_evicted_keys));
+  CUDA_CHECK(cudaFree(d_evicted_values));
+  CUDA_CHECK(cudaFree(d_evicted_scores));
+  CUDA_CHECK(cudaFree(d_counter));
+}
+
+TEST(DualBucketTest, AccumOrAssignGuard) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+  Table table;
+  create_memory_mode_table(table, 128 * 128);
+
+  K* d_keys;
+  V* d_values;
+  bool* d_accum;
+  CUDA_CHECK(cudaMalloc(&d_keys, sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_accum, sizeof(bool)));
+
+  EXPECT_THROW(table.accum_or_assign(1, d_keys, d_values, d_accum),
+               std::runtime_error);
+
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+  CUDA_CHECK(cudaFree(d_accum));
+}
+
+TEST(DualBucketTest, AssignScoresGuard) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+  Table table;
+  create_memory_mode_table(table, 128 * 128);
+
+  K* d_keys;
+  S* d_scores;
+  CUDA_CHECK(cudaMalloc(&d_keys, sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_scores, sizeof(S)));
+
+  EXPECT_THROW(table.assign_scores(1, d_keys, d_scores), std::runtime_error);
+
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_scores));
+}
+
+TEST(DualBucketTest, AssignValuesGuard) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+  Table table;
+  create_memory_mode_table(table, 128 * 128);
+
+  K* d_keys;
+  V* d_values;
+  CUDA_CHECK(cudaMalloc(&d_keys, sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, DIM * sizeof(V)));
+
+  EXPECT_THROW(table.assign_values(1, d_keys, d_values), std::runtime_error);
+
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+}
+
+// ===================================
+// TestGroup 5 addition: max_hbm_for_vectors rejection
+// ===================================
+
+TEST(DualBucketTest, InitHbmForVectorsReject) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+  Table table;
+
+  TableOptions options;
+  options.init_capacity = 128 * 128;
+  options.max_capacity = 128 * 128;
+  options.max_hbm_for_vectors = 1024;  // non-zero → should be rejected
+  options.dim = DIM;
+  options.max_bucket_size = 128;
+  options.table_mode = TableMode::kMemory;
+
+  EXPECT_THROW(table.init(options), std::runtime_error);
+}
+
+// T5.3: dim > 224 rejected in MEMORY_MODE (shared-memory buffer overflow).
+TEST(DualBucketTest, InitDimTooLargeReject) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+  Table table;
+
+  TableOptions options;
+  options.init_capacity = 128 * 128;
+  options.max_capacity = 128 * 128;
+  options.max_hbm_for_vectors = 0;
+  options.dim = 256;  // exceeds 224-float limit
+  options.max_bucket_size = 128;
+  options.table_mode = TableMode::kMemory;
+
+  EXPECT_THROW(table.init(options), std::runtime_error);
+}
+
+// T5.3b: dim=224 should be accepted (exact boundary).
+TEST(DualBucketTest, InitDimMaxAccepted) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+  Table table;
+
+  TableOptions options;
+  options.init_capacity = 128 * 128;
+  options.max_capacity = 128 * 128;
+  options.max_hbm_for_vectors = 0;
+  options.dim = 224;  // exactly at the limit
+  options.max_bucket_size = 128;
+  options.table_mode = TableMode::kMemory;
+
+  EXPECT_NO_THROW(table.init(options));
+}
+
+// ===================================
+// TestGroup 2 addition: Bucket distribution (T2.1)
+// ===================================
+
+// Verify that keys are distributed across multiple buckets (not all in b1).
+// We insert random keys and check that after export, the table size matches
+// expectations.  A more direct check would require bucket-level introspection
+// which the public API does not expose, but we can infer distribution by
+// checking that the first-eviction LF is significantly higher than single-
+// bucket mode (covered in FirstEvictionLoadFactor).  Here we do a simple
+// idempotency + size check with random keys to stress the hash distribution.
+TEST(DualBucketTest, RandomKeyDistribution) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+  constexpr size_t CAPACITY = 128 * 128;  // 16384 slots
+  constexpr size_t N = 8192;              // 50% LF
+
+  Table table;
+  create_memory_mode_table(table, CAPACITY);
+
+  std::vector<K> h_keys(N);
+  std::vector<V> h_values(N * DIM, 1.0f);
+  std::vector<S> h_scores(N);
+
+  std::mt19937_64 rng(12345);
+  for (size_t i = 0; i < N; i++) {
+    h_keys[i] = (rng() & 0x00FFFFFFFFFFFFFF) | 1;
+    h_scores[i] = i + 1;
+  }
+
+  K* d_keys;
+  V* d_values;
+  S* d_scores;
+  bool* d_founds;
+  V* d_found_values;
+  CUDA_CHECK(cudaMalloc(&d_keys, N * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, N * DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_scores, N * sizeof(S)));
+  CUDA_CHECK(cudaMalloc(&d_founds, N * sizeof(bool)));
+  CUDA_CHECK(cudaMalloc(&d_found_values, N * DIM * sizeof(V)));
+
+  CUDA_CHECK(
+      cudaMemcpy(d_keys, h_keys.data(), N * sizeof(K), cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_values, h_values.data(), N * DIM * sizeof(V),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_scores, h_scores.data(), N * sizeof(S),
+                        cudaMemcpyHostToDevice));
+
+  table.insert_or_assign(N, d_keys, d_values, d_scores, 0, true);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  size_t table_size = table.size(0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+  EXPECT_EQ(table_size, N)
+      << "Random keys at 50% LF should all be inserted without eviction";
+
+  // Re-insert the same keys (idempotent).
+  table.insert_or_assign(N, d_keys, d_values, d_scores, 0, true);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  size_t table_size_after = table.size(0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+  EXPECT_EQ(table_size_after, N) << "Re-insert must not create duplicates";
+
+  // Find all.
+  table.find(N, d_keys, d_found_values, d_founds, nullptr, 0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  bool* h_founds = new bool[N];
+  CUDA_CHECK(
+      cudaMemcpy(h_founds, d_founds, N * sizeof(bool), cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < N; i++) {
+    EXPECT_TRUE(h_founds[i]) << "Random key " << h_keys[i] << " not found";
+  }
+
+  delete[] h_founds;
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+  CUDA_CHECK(cudaFree(d_scores));
+  CUDA_CHECK(cudaFree(d_founds));
+  CUDA_CHECK(cudaFree(d_found_values));
+}
+
+// ===================================
+// TestGroup 4 addition: Single bucket capacity (T4.2)
+// ===================================
+
+// T4.2: Single-bucket capacity must be rejected by MEMORY_MODE init guard.
+// Dual-bucket addressing requires at least 2 buckets (capacity >= 256).
+TEST(DualBucketTest, SingleBucketCapacityRejected) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+  Table table;
+
+  // 1 bucket = 128 slots → must be rejected.
+  EXPECT_THROW(create_memory_mode_table(table, 128), std::runtime_error);
+}
+
+// T4.2b: Minimum valid capacity (2 buckets = 256 slots).
+TEST(DualBucketTest, MinimumTwoBucketCapacity) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+  constexpr size_t CAPACITY = 256;  // 2 buckets
+  constexpr size_t N = 128;
+
+  Table table;
+  create_memory_mode_table(table, CAPACITY);
+
+  std::vector<K> h_keys(N);
+  std::vector<V> h_values(N * DIM, 1.0f);
+  std::vector<S> h_scores(N);
+
+  std::iota(h_keys.begin(), h_keys.end(), 1);
+  for (size_t i = 0; i < N; i++) h_scores[i] = i + 1;
+
+  K* d_keys;
+  V* d_values;
+  S* d_scores;
+  bool* d_founds;
+  V* d_found_values;
+  CUDA_CHECK(cudaMalloc(&d_keys, N * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, N * DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_scores, N * sizeof(S)));
+  CUDA_CHECK(cudaMalloc(&d_founds, N * sizeof(bool)));
+  CUDA_CHECK(cudaMalloc(&d_found_values, N * DIM * sizeof(V)));
+
+  CUDA_CHECK(
+      cudaMemcpy(d_keys, h_keys.data(), N * sizeof(K), cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_values, h_values.data(), N * DIM * sizeof(V),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_scores, h_scores.data(), N * sizeof(S),
+                        cudaMemcpyHostToDevice));
+
+  table.insert_or_assign(N, d_keys, d_values, d_scores, 0, true);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  size_t table_size = table.size(0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+  EXPECT_EQ(table_size, N);
+
+  table.find(N, d_keys, d_found_values, d_founds, nullptr, 0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  bool* h_founds = new bool[N];
+  CUDA_CHECK(
+      cudaMemcpy(h_founds, d_founds, N * sizeof(bool), cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < N; i++) {
+    EXPECT_TRUE(h_founds[i])
+        << "Two-bucket: Key " << h_keys[i] << " not found";
+  }
+
+  delete[] h_founds;
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+  CUDA_CHECK(cudaFree(d_scores));
+  CUDA_CHECK(cudaFree(d_founds));
+  CUDA_CHECK(cudaFree(d_found_values));
+}
+
+// ===================================
+// DEBUG: 2-bucket eviction trace
+// ===================================
+
+// Small-scale eviction test with kernel printf enabled (buckets_num <= 4).
+// Fill 2 buckets (256 slots), then insert 4 high-score keys and trace D2.
+TEST(DualBucketTest, DebugEvictionTrace) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+  constexpr size_t NUM_BUCKETS = 2;
+  constexpr size_t CAPACITY = NUM_BUCKETS * 128;  // 256 slots
+  constexpr size_t N_FILL = CAPACITY;             // Fill completely
+  constexpr size_t N_NEW = 4;  // Insert a few high-score keys
+
+  Table table;
+  create_memory_mode_table(table, CAPACITY);
+
+  // Phase 1: Fill with scores 1..256.
+  std::vector<K> h_keys_fill(N_FILL);
+  std::vector<V> h_values_fill(N_FILL * DIM, 1.0f);
+  std::vector<S> h_scores_fill(N_FILL);
+
+  std::iota(h_keys_fill.begin(), h_keys_fill.end(), 1);
+  for (size_t i = 0; i < N_FILL; i++) {
+    h_scores_fill[i] = i + 1;
+  }
+
+  K* d_keys;
+  V* d_values;
+  S* d_scores;
+  CUDA_CHECK(cudaMalloc(&d_keys, N_FILL * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, N_FILL * DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_scores, N_FILL * sizeof(S)));
+
+  CUDA_CHECK(cudaMemcpy(d_keys, h_keys_fill.data(), N_FILL * sizeof(K),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_values, h_values_fill.data(),
+                        N_FILL * DIM * sizeof(V), cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_scores, h_scores_fill.data(), N_FILL * sizeof(S),
+                        cudaMemcpyHostToDevice));
+
+  table.insert_or_assign(N_FILL, d_keys, d_values, d_scores, 0, true);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  size_t table_size_after_fill = table.size(0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+  std::cout << "[DebugEviction] After fill: table_size="
+            << table_size_after_fill << " capacity=" << CAPACITY << std::endl;
+
+  // Verify fill: find all N_FILL keys to check b2 lookup correctness.
+  {
+    bool* d_fill_founds;
+    V* d_fill_found_vals;
+    CUDA_CHECK(cudaMalloc(&d_fill_founds, N_FILL * sizeof(bool)));
+    CUDA_CHECK(cudaMalloc(&d_fill_found_vals, N_FILL * DIM * sizeof(V)));
+    CUDA_CHECK(cudaMemcpy(d_keys, h_keys_fill.data(), N_FILL * sizeof(K),
+                          cudaMemcpyHostToDevice));
+    table.find(N_FILL, d_keys, d_fill_found_vals, d_fill_founds, nullptr, 0);
+    CUDA_CHECK(cudaDeviceSynchronize());
+    bool* h_fill_founds = new bool[N_FILL];
+    CUDA_CHECK(cudaMemcpy(h_fill_founds, d_fill_founds, N_FILL * sizeof(bool),
+                          cudaMemcpyDeviceToHost));
+    int fill_found = 0;
+    for (size_t i = 0; i < N_FILL; i++) {
+      if (h_fill_founds[i]) {
+        fill_found++;
+      } else {
+        std::cout << "[DebugEviction] MISSING fill key=" << h_keys_fill[i]
+                  << " (index=" << i << ")" << std::endl;
+      }
+    }
+    std::cout << "[DebugEviction] Fill verify: found " << fill_found << "/"
+              << N_FILL << " keys" << std::endl;
+    delete[] h_fill_founds;
+    CUDA_CHECK(cudaFree(d_fill_founds));
+    CUDA_CHECK(cudaFree(d_fill_found_vals));
+  }
+
+  // Phase 2: Insert high-score keys.
+  std::vector<K> h_keys_new(N_NEW);
+  std::vector<V> h_values_new(N_NEW * DIM, 2.0f);
+  std::vector<S> h_scores_new(N_NEW);
+
+  for (size_t i = 0; i < N_NEW; i++) {
+    h_keys_new[i] = N_FILL + 100 + i;
+    h_scores_new[i] = 10000 + i;
+  }
+
+  std::cout << "[DebugEviction] Inserting " << N_NEW << " high-score keys "
+            << "(scores " << h_scores_new[0] << ".." << h_scores_new[N_NEW - 1]
+            << ")" << std::endl;
+
+  CUDA_CHECK(cudaMemcpy(d_keys, h_keys_new.data(), N_NEW * sizeof(K),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_values, h_values_new.data(), N_NEW * DIM * sizeof(V),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_scores, h_scores_new.data(), N_NEW * sizeof(S),
+                        cudaMemcpyHostToDevice));
+
+  table.insert_or_assign(N_NEW, d_keys, d_values, d_scores, 0, true);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  size_t table_size_after_evict = table.size(0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+  std::cout << "[DebugEviction] After evict-insert: table_size="
+            << table_size_after_evict << std::endl;
+
+  // Phase 3: Find the high-score keys.
+  bool* d_founds;
+  CUDA_CHECK(cudaMalloc(&d_founds, N_NEW * sizeof(bool)));
+  V* d_found_values;
+  CUDA_CHECK(cudaMalloc(&d_found_values, N_NEW * DIM * sizeof(V)));
+
+  CUDA_CHECK(cudaMemcpy(d_keys, h_keys_new.data(), N_NEW * sizeof(K),
+                        cudaMemcpyHostToDevice));
+  table.find(N_NEW, d_keys, d_found_values, d_founds, nullptr, 0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  bool* h_founds = new bool[N_NEW];
+  CUDA_CHECK(cudaMemcpy(h_founds, d_founds, N_NEW * sizeof(bool),
+                        cudaMemcpyDeviceToHost));
+  int found_count = 0;
+  for (size_t i = 0; i < N_NEW; i++) {
+    std::cout << "[DebugEviction] key=" << h_keys_new[i]
+              << " score=" << h_scores_new[i]
+              << " found=" << (h_founds[i] ? "YES" : "NO") << std::endl;
+    if (h_founds[i]) found_count++;
+  }
+  std::cout << "[DebugEviction] Found " << found_count << "/" << N_NEW
+            << std::endl;
+
+  EXPECT_EQ(found_count, static_cast<int>(N_NEW))
+      << "All high-score keys should survive eviction in 2-bucket table";
+
+  delete[] h_founds;
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+  CUDA_CHECK(cudaFree(d_scores));
+  CUDA_CHECK(cudaFree(d_founds));
+  CUDA_CHECK(cudaFree(d_found_values));
+}
+
+// ===================================
+// TestGroup 2 addition: Eviction Quality (T2.6)
+// ===================================
+
+// T2.6: After inserting 5x capacity keys with random scores, the surviving keys
+// in the table should overlap with the theoretical top-capacity scores by at
+// least 98%.  This validates that dual-bucket score-based eviction correctly
+// retains high-score keys under sustained oversubscription pressure.
+TEST(DualBucketTest, EvictionQualityAtFullLoad) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+  constexpr size_t CAPACITY = 128 * 1024;      // 128K slots
+  constexpr size_t TOTAL_KEYS = 5 * CAPACITY;  // 5x oversubscription
+  constexpr size_t BATCH = CAPACITY;           // One capacity per batch
+  constexpr double QUALITY_THRESHOLD = 0.995;
+
+  Table table;
+  create_memory_mode_table(table, CAPACITY);
+
+  // Generate all keys (1..TOTAL_KEYS) with random scores.
+  std::vector<K> all_keys(TOTAL_KEYS);
+  std::vector<S> all_scores(TOTAL_KEYS);
+  std::iota(all_keys.begin(), all_keys.end(), 1);
+
+  std::mt19937_64 rng(42);
+  for (size_t i = 0; i < TOTAL_KEYS; i++) {
+    all_scores[i] = (rng() >> 1) | 1;  // Positive, non-zero
+  }
+
+  // Allocate device memory for one batch.
+  K* d_keys;
+  V* d_values;
+  S* d_scores;
+  CUDA_CHECK(cudaMalloc(&d_keys, BATCH * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, BATCH * DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_scores, BATCH * sizeof(S)));
+
+  std::vector<V> h_values(BATCH * DIM, 1.0f);
+
+  // Insert all keys in 5 batches.
+  for (size_t offset = 0; offset < TOTAL_KEYS; offset += BATCH) {
+    size_t n = std::min(BATCH, TOTAL_KEYS - offset);
+    CUDA_CHECK(cudaMemcpy(d_keys, all_keys.data() + offset, n * sizeof(K),
+                          cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_values, h_values.data(), n * DIM * sizeof(V),
+                          cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_scores, all_scores.data() + offset, n * sizeof(S),
+                          cudaMemcpyHostToDevice));
+    table.insert_or_assign(n, d_keys, d_values, d_scores, 0, true);
+    CUDA_CHECK(cudaDeviceSynchronize());
+  }
+
+  // Export surviving keys and scores.
+  size_t table_size = table.size(0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  K* d_dump_keys;
+  V* d_dump_values;
+  S* d_dump_scores;
+  size_t* d_dump_counter;
+  CUDA_CHECK(cudaMalloc(&d_dump_keys, table_size * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_dump_values, table_size * DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_dump_scores, table_size * sizeof(S)));
+  CUDA_CHECK(cudaMalloc(&d_dump_counter, sizeof(size_t)));
+  CUDA_CHECK(cudaMemset(d_dump_counter, 0, sizeof(size_t)));
+
+  table.export_batch(table_size, 0, d_dump_counter, d_dump_keys, d_dump_values,
+                     d_dump_scores, 0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  size_t dumped;
+  CUDA_CHECK(cudaMemcpy(&dumped, d_dump_counter, sizeof(size_t),
+                        cudaMemcpyDeviceToHost));
+
+  std::vector<K> h_dump_keys(dumped);
+  CUDA_CHECK(cudaMemcpy(h_dump_keys.data(), d_dump_keys, dumped * sizeof(K),
+                        cudaMemcpyDeviceToHost));
+
+  // Compute the ideal top-`dumped` set: keys with the highest scores out of
+  // all TOTAL_KEYS inserted during the entire test.
+  std::vector<std::pair<S, K>> score_key_pairs(TOTAL_KEYS);
+  for (size_t i = 0; i < TOTAL_KEYS; i++) {
+    score_key_pairs[i] = {all_scores[i], all_keys[i]};
+  }
+  std::sort(score_key_pairs.begin(), score_key_pairs.end(),
+            [](const auto& a, const auto& b) { return a.first > b.first; });
+
+  std::unordered_set<K> ideal_set;
+  for (size_t i = 0; i < dumped && i < TOTAL_KEYS; i++) {
+    ideal_set.insert(score_key_pairs[i].second);
+  }
+
+  // Count overlap between surviving keys and ideal set.
+  size_t overlap = 0;
+  for (size_t i = 0; i < dumped; i++) {
+    if (ideal_set.count(h_dump_keys[i])) overlap++;
+  }
+
+  double quality = static_cast<double>(overlap) / static_cast<double>(dumped);
+  std::cout << "[EvictionQuality] Table size: " << dumped << "/" << CAPACITY
+            << " (LF=" << (static_cast<double>(dumped) / CAPACITY) << ")"
+            << std::endl;
+  std::cout << "[EvictionQuality] Overlap with ideal top-" << dumped << ": "
+            << overlap << "/" << dumped << " (quality=" << (quality * 100.0)
+            << "%)" << std::endl;
+
+  EXPECT_GE(quality, QUALITY_THRESHOLD)
+      << "Eviction quality " << (quality * 100.0) << "% is below "
+      << (QUALITY_THRESHOLD * 100.0) << "% threshold";
+
+  // Cleanup.
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+  CUDA_CHECK(cudaFree(d_scores));
+  CUDA_CHECK(cudaFree(d_dump_keys));
+  CUDA_CHECK(cudaFree(d_dump_values));
+  CUDA_CHECK(cudaFree(d_dump_scores));
+  CUDA_CHECK(cudaFree(d_dump_counter));
+}
+
+// ===================================
+// TestGroup 6: Concurrency Stress Tests
+// ===================================
+
+// T6.1: Multi-stream concurrent upsert stress test.
+// Multiple CUDA streams issue insert_or_assign concurrently to stress Phase 2
+// eviction's stale-score handling.  Under high contention some inserts may be
+// REFUSED, but the table must remain consistent: no crashes, no duplicates,
+// and all surviving keys must be findable.
+TEST(DualBucketTest, MultiStreamConcurrentUpsert) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+  constexpr size_t CAPACITY = 128 * 1024;    // 128K slots
+  constexpr int NUM_STREAMS = 4;
+  constexpr size_t KEYS_PER_STREAM = CAPACITY;  // Each stream fills capacity
+  constexpr size_t TOTAL_KEYS = NUM_STREAMS * KEYS_PER_STREAM;
+
+  Table table;
+  create_memory_mode_table(table, CAPACITY);
+
+  // Create CUDA streams.
+  cudaStream_t streams[NUM_STREAMS];
+  for (int s = 0; s < NUM_STREAMS; s++) {
+    CUDA_CHECK(cudaStreamCreate(&streams[s]));
+  }
+
+  // Prepare per-stream device memory and data.
+  K* d_keys[NUM_STREAMS];
+  V* d_values[NUM_STREAMS];
+  S* d_scores[NUM_STREAMS];
+
+  std::mt19937_64 rng(42);
+  for (int s = 0; s < NUM_STREAMS; s++) {
+    CUDA_CHECK(cudaMalloc(&d_keys[s], KEYS_PER_STREAM * sizeof(K)));
+    CUDA_CHECK(cudaMalloc(&d_values[s], KEYS_PER_STREAM * DIM * sizeof(V)));
+    CUDA_CHECK(cudaMalloc(&d_scores[s], KEYS_PER_STREAM * sizeof(S)));
+
+    std::vector<K> h_keys(KEYS_PER_STREAM);
+    std::vector<V> h_values(KEYS_PER_STREAM * DIM, static_cast<V>(s + 1));
+    std::vector<S> h_scores(KEYS_PER_STREAM);
+
+    for (size_t i = 0; i < KEYS_PER_STREAM; i++) {
+      // Use non-overlapping key ranges per stream.
+      h_keys[i] = s * KEYS_PER_STREAM + i + 1;
+      h_scores[i] = (rng() >> 1) | 1;  // Random positive score
+    }
+
+    CUDA_CHECK(cudaMemcpy(d_keys[s], h_keys.data(),
+                          KEYS_PER_STREAM * sizeof(K),
+                          cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_values[s], h_values.data(),
+                          KEYS_PER_STREAM * DIM * sizeof(V),
+                          cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_scores[s], h_scores.data(),
+                          KEYS_PER_STREAM * sizeof(S),
+                          cudaMemcpyHostToDevice));
+  }
+
+  // Launch concurrent inserts on all streams simultaneously.
+  for (int s = 0; s < NUM_STREAMS; s++) {
+    table.insert_or_assign(KEYS_PER_STREAM, d_keys[s], d_values[s],
+                           d_scores[s], streams[s], /*unique_key=*/true);
+  }
+
+  // Synchronize all streams.
+  for (int s = 0; s < NUM_STREAMS; s++) {
+    CUDA_CHECK(cudaStreamSynchronize(streams[s]));
+  }
+
+  // Verify table consistency.
+  size_t table_size = table.size(0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+  std::cout << "[MultiStream] Table size after concurrent inserts: "
+            << table_size << "/" << CAPACITY << std::endl;
+
+  // Table size must not exceed capacity (no overflow).
+  EXPECT_LE(table_size, CAPACITY);
+  // Some keys should have been inserted (table should not be empty).
+  EXPECT_GT(table_size, static_cast<size_t>(0));
+
+  // Export all surviving keys and verify they are findable.
+  K* d_dump_keys;
+  V* d_dump_values;
+  S* d_dump_scores;
+  size_t* d_dump_counter;
+  CUDA_CHECK(cudaMalloc(&d_dump_keys, table_size * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_dump_values, table_size * DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_dump_scores, table_size * sizeof(S)));
+  CUDA_CHECK(cudaMalloc(&d_dump_counter, sizeof(size_t)));
+  CUDA_CHECK(cudaMemset(d_dump_counter, 0, sizeof(size_t)));
+
+  table.export_batch(table_size, 0, d_dump_counter, d_dump_keys, d_dump_values,
+                     d_dump_scores, 0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  size_t dumped;
+  CUDA_CHECK(cudaMemcpy(&dumped, d_dump_counter, sizeof(size_t),
+                        cudaMemcpyDeviceToHost));
+  EXPECT_EQ(dumped, table_size);
+
+  // Find all exported keys — every surviving key must be findable.
+  bool* d_founds;
+  V* d_found_values;
+  CUDA_CHECK(cudaMalloc(&d_founds, dumped * sizeof(bool)));
+  CUDA_CHECK(cudaMalloc(&d_found_values, dumped * DIM * sizeof(V)));
+
+  table.find(dumped, d_dump_keys, d_found_values, d_founds, nullptr, 0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  bool* h_founds = new bool[dumped];
+  CUDA_CHECK(cudaMemcpy(h_founds, d_founds, dumped * sizeof(bool),
+                        cudaMemcpyDeviceToHost));
+
+  int found_count = 0;
+  for (size_t i = 0; i < dumped; i++) {
+    if (h_founds[i]) found_count++;
+  }
+  std::cout << "[MultiStream] Find consistency: " << found_count << "/"
+            << dumped << std::endl;
+  EXPECT_EQ(found_count, static_cast<int>(dumped))
+      << "All surviving keys must be findable after concurrent upserts";
+
+  // Check no duplicates: export size must match table.size().
+  std::vector<K> h_dump_keys(dumped);
+  CUDA_CHECK(cudaMemcpy(h_dump_keys.data(), d_dump_keys, dumped * sizeof(K),
+                        cudaMemcpyDeviceToHost));
+  std::unordered_set<K> unique_keys(h_dump_keys.begin(), h_dump_keys.end());
+  EXPECT_EQ(unique_keys.size(), dumped) << "Duplicate keys found in table";
+
+  // Cleanup.
+  delete[] h_founds;
+  for (int s = 0; s < NUM_STREAMS; s++) {
+    CUDA_CHECK(cudaFree(d_keys[s]));
+    CUDA_CHECK(cudaFree(d_values[s]));
+    CUDA_CHECK(cudaFree(d_scores[s]));
+    CUDA_CHECK(cudaStreamDestroy(streams[s]));
+  }
+  CUDA_CHECK(cudaFree(d_dump_keys));
+  CUDA_CHECK(cudaFree(d_dump_values));
+  CUDA_CHECK(cudaFree(d_dump_scores));
+  CUDA_CHECK(cudaFree(d_dump_counter));
+  CUDA_CHECK(cudaFree(d_founds));
+  CUDA_CHECK(cudaFree(d_found_values));
+}
+
+// T6.2: Multi-stream concurrent upsert with overlapping keys.
+// Tests that concurrent streams inserting the same keys do not create
+// duplicates, and that the final values/scores are consistent.
+TEST(DualBucketTest, MultiStreamOverlappingKeys) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+  constexpr size_t CAPACITY = 128 * 1024;
+  constexpr int NUM_STREAMS = 4;
+  constexpr size_t N = 32768;  // Shared key set
+
+  Table table;
+  create_memory_mode_table(table, CAPACITY);
+
+  cudaStream_t streams[NUM_STREAMS];
+  for (int s = 0; s < NUM_STREAMS; s++) {
+    CUDA_CHECK(cudaStreamCreate(&streams[s]));
+  }
+
+  // All streams insert the SAME keys with different scores.
+  std::vector<K> h_keys(N);
+  std::iota(h_keys.begin(), h_keys.end(), 1);
+
+  K* d_keys[NUM_STREAMS];
+  V* d_values[NUM_STREAMS];
+  S* d_scores[NUM_STREAMS];
+
+  for (int s = 0; s < NUM_STREAMS; s++) {
+    CUDA_CHECK(cudaMalloc(&d_keys[s], N * sizeof(K)));
+    CUDA_CHECK(cudaMalloc(&d_values[s], N * DIM * sizeof(V)));
+    CUDA_CHECK(cudaMalloc(&d_scores[s], N * sizeof(S)));
+
+    std::vector<V> h_values(N * DIM, static_cast<V>(s + 1));
+    std::vector<S> h_scores(N);
+    for (size_t i = 0; i < N; i++) {
+      h_scores[i] = (s + 1) * 1000 + i;  // Different scores per stream
+    }
+
+    CUDA_CHECK(cudaMemcpy(d_keys[s], h_keys.data(), N * sizeof(K),
+                          cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_values[s], h_values.data(), N * DIM * sizeof(V),
+                          cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_scores[s], h_scores.data(), N * sizeof(S),
+                          cudaMemcpyHostToDevice));
+  }
+
+  // Launch concurrent inserts.
+  for (int s = 0; s < NUM_STREAMS; s++) {
+    table.insert_or_assign(N, d_keys[s], d_values[s], d_scores[s], streams[s],
+                           true);
+  }
+
+  for (int s = 0; s < NUM_STREAMS; s++) {
+    CUDA_CHECK(cudaStreamSynchronize(streams[s]));
+  }
+
+  // Table size must equal N (no duplicates from concurrent inserts).
+  size_t table_size = table.size(0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+  std::cout << "[MultiStreamOverlap] Table size: " << table_size
+            << " (expected " << N << ")" << std::endl;
+  EXPECT_EQ(table_size, N) << "Concurrent inserts of same keys created "
+                           << (table_size - N) << " duplicates";
+
+  // All keys must be findable.
+  bool* d_founds;
+  V* d_found_values;
+  CUDA_CHECK(cudaMalloc(&d_founds, N * sizeof(bool)));
+  CUDA_CHECK(cudaMalloc(&d_found_values, N * DIM * sizeof(V)));
+
+  table.find(N, d_keys[0], d_found_values, d_founds, nullptr, 0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  bool* h_founds = new bool[N];
+  CUDA_CHECK(
+      cudaMemcpy(h_founds, d_founds, N * sizeof(bool), cudaMemcpyDeviceToHost));
+
+  int found_count = 0;
+  for (size_t i = 0; i < N; i++) {
+    if (h_founds[i]) found_count++;
+  }
+  EXPECT_EQ(found_count, static_cast<int>(N))
+      << "All keys must be findable after concurrent overlapping inserts";
+
+  // Cleanup.
+  delete[] h_founds;
+  for (int s = 0; s < NUM_STREAMS; s++) {
+    CUDA_CHECK(cudaFree(d_keys[s]));
+    CUDA_CHECK(cudaFree(d_values[s]));
+    CUDA_CHECK(cudaFree(d_scores[s]));
+    CUDA_CHECK(cudaStreamDestroy(streams[s]));
+  }
+  CUDA_CHECK(cudaFree(d_founds));
+  CUDA_CHECK(cudaFree(d_found_values));
+}
+
+// ===================================
+// TestGroup 7: Additional Missing Tests
+// ===================================
+
+// T7.1: Find with scores=nullptr (CopyScoreEmpty path).
+TEST(DualBucketTest, FindWithNullScores) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+  constexpr size_t CAPACITY = 128 * 128;
+  constexpr size_t N = 1024;
+
+  Table table;
+  create_memory_mode_table(table, CAPACITY);
+
+  std::vector<K> h_keys(N);
+  std::vector<V> h_values(N * DIM, 1.0f);
+  std::vector<S> h_scores(N);
+
+  std::iota(h_keys.begin(), h_keys.end(), 1);
+  for (size_t i = 0; i < N; i++) h_scores[i] = i + 1;
+
+  K* d_keys;
+  V* d_values;
+  S* d_scores;
+  bool* d_founds;
+  V* d_found_values;
+  S* d_found_scores;
+  CUDA_CHECK(cudaMalloc(&d_keys, N * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, N * DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_scores, N * sizeof(S)));
+  CUDA_CHECK(cudaMalloc(&d_founds, N * sizeof(bool)));
+  CUDA_CHECK(cudaMalloc(&d_found_values, N * DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_found_scores, N * sizeof(S)));
+
+  CUDA_CHECK(
+      cudaMemcpy(d_keys, h_keys.data(), N * sizeof(K), cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_values, h_values.data(), N * DIM * sizeof(V),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_scores, h_scores.data(), N * sizeof(S),
+                        cudaMemcpyHostToDevice));
+
+  table.insert_or_assign(N, d_keys, d_values, d_scores, 0, true);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  // Find with scores=nullptr (CopyScoreEmpty branch).
+  table.find(N, d_keys, d_found_values, d_founds, /*scores=*/nullptr, 0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  bool* h_founds = new bool[N];
+  CUDA_CHECK(
+      cudaMemcpy(h_founds, d_founds, N * sizeof(bool), cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < N; i++) {
+    EXPECT_TRUE(h_founds[i]) << "Key " << h_keys[i] << " not found (null scores)";
+  }
+
+  // Find with scores!=nullptr (CopyScoreByPassCache branch).
+  table.find(N, d_keys, d_found_values, d_founds, d_found_scores, 0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  CUDA_CHECK(
+      cudaMemcpy(h_founds, d_founds, N * sizeof(bool), cudaMemcpyDeviceToHost));
+  std::vector<S> h_found_scores(N);
+  CUDA_CHECK(cudaMemcpy(h_found_scores.data(), d_found_scores, N * sizeof(S),
+                        cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < N; i++) {
+    EXPECT_TRUE(h_founds[i])
+        << "Key " << h_keys[i] << " not found (with scores)";
+    if (h_founds[i]) {
+      EXPECT_GT(h_found_scores[i], static_cast<S>(0))
+          << "Score should be non-zero for key " << h_keys[i];
+    }
+  }
+
+  delete[] h_founds;
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+  CUDA_CHECK(cudaFree(d_scores));
+  CUDA_CHECK(cudaFree(d_founds));
+  CUDA_CHECK(cudaFree(d_found_values));
+  CUDA_CHECK(cudaFree(d_found_scores));
+}
+
+// T7.2: Clear then re-insert (verifies dual_bucket_empty_digest reset).
+TEST(DualBucketTest, ClearAndReinsert) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+
+  constexpr size_t CAPACITY = 128 * 128;
+  constexpr size_t N = 2048;
+
+  Table table;
+  create_memory_mode_table(table, CAPACITY);
+
+  std::vector<K> h_keys(N);
+  std::vector<V> h_values(N * DIM, 1.0f);
+  std::vector<S> h_scores(N);
+
+  std::iota(h_keys.begin(), h_keys.end(), 1);
+  for (size_t i = 0; i < N; i++) h_scores[i] = i + 1;
+
+  K* d_keys;
+  V* d_values;
+  S* d_scores;
+  bool* d_founds;
+  V* d_found_values;
+  CUDA_CHECK(cudaMalloc(&d_keys, N * sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, N * DIM * sizeof(V)));
+  CUDA_CHECK(cudaMalloc(&d_scores, N * sizeof(S)));
+  CUDA_CHECK(cudaMalloc(&d_founds, N * sizeof(bool)));
+  CUDA_CHECK(cudaMalloc(&d_found_values, N * DIM * sizeof(V)));
+
+  CUDA_CHECK(
+      cudaMemcpy(d_keys, h_keys.data(), N * sizeof(K), cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_values, h_values.data(), N * DIM * sizeof(V),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_scores, h_scores.data(), N * sizeof(S),
+                        cudaMemcpyHostToDevice));
+
+  // Insert first batch.
+  table.insert_or_assign(N, d_keys, d_values, d_scores, 0, true);
+  CUDA_CHECK(cudaDeviceSynchronize());
+  EXPECT_EQ(table.size(0), N);
+
+  // Clear the table.
+  table.clear(0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+  EXPECT_EQ(table.size(0), static_cast<size_t>(0));
+
+  // Re-insert different keys.
+  std::vector<K> h_keys2(N);
+  std::iota(h_keys2.begin(), h_keys2.end(), N + 1);  // Different keys
+  CUDA_CHECK(cudaMemcpy(d_keys, h_keys2.data(), N * sizeof(K),
+                        cudaMemcpyHostToDevice));
+
+  table.insert_or_assign(N, d_keys, d_values, d_scores, 0, true);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  size_t table_size = table.size(0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+  EXPECT_EQ(table_size, N)
+      << "After clear + re-insert, table should have N entries";
+
+  // Verify new keys are findable.
+  table.find(N, d_keys, d_found_values, d_founds, nullptr, 0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  bool* h_founds = new bool[N];
+  CUDA_CHECK(
+      cudaMemcpy(h_founds, d_founds, N * sizeof(bool), cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < N; i++) {
+    EXPECT_TRUE(h_founds[i])
+        << "Key " << h_keys2[i] << " not found after clear + re-insert";
+  }
+
+  // Verify old keys are NOT findable.
+  CUDA_CHECK(cudaMemcpy(d_keys, h_keys.data(), N * sizeof(K),
+                        cudaMemcpyHostToDevice));
+  table.find(N, d_keys, d_found_values, d_founds, nullptr, 0);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  CUDA_CHECK(
+      cudaMemcpy(h_founds, d_founds, N * sizeof(bool), cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < N; i++) {
+    EXPECT_FALSE(h_founds[i])
+        << "Old key " << h_keys[i] << " still found after clear";
+  }
+
+  delete[] h_founds;
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+  CUDA_CHECK(cudaFree(d_scores));
+  CUDA_CHECK(cudaFree(d_founds));
+  CUDA_CHECK(cudaFree(d_found_values));
+}


### PR DESCRIPTION
## Dual-Bucket Hashing for Memory-Optimized GPU Hash Table (`TableMode::kMemory`)

### Algorithm Overview

This PR implements **two-choice hashing** (a d-left hashing variant) for `TableMode::kMemory`, enabling near-100% load factor on GPU hash tables without rehashing.

**Bucket addressing.** Each key is hashed with Murmur3-128 to produce a 128-bit digest. The two candidate buckets are derived as: `b1 = hash[0:63] mod N`, `b2 = hash[64:127] mod N`, where N is the number of buckets. An 8-bit tag (`digest = hash[56:63]`) is stored per slot for fast negative filtering.

**Three-phase upsert pipeline:**
- **Phase 0 (Duplicate scan):** All 32 threads in a warp cooperatively scan both b1 and b2 for an existing copy of the key (digest match → full key compare). If found, the value and score are updated in-place.
- **Phase 1 (Two-choice insert):** If the key is new, threads probe for an empty slot. The bucket with more free slots is preferred (power-of-two-choices), reducing worst-case clustering.
- **Phase 2 (Score-based eviction):** When both buckets are full, a CAS-based eviction loop replaces the lowest-scoring entry across both buckets, followed by a re-verification pass to prevent duplicate insertion under concurrency.

**Two-pass lookup:** Pass 1 scans b1 with digest filtering and early-exits on match. Pass 2 scans b2 only on miss. A register-cached digest eliminates redundant Murmur3 recomputation between passes.

**Kernel architecture:** 128-thread blocks, 32 threads per key (one warp), 128-slot buckets, async global→shared memory pipeline (`cp.async`), and shared-memory-resident digest arrays for both bucket scans.

### Benchmark Results

**Platform:** NVIDIA RTX A6000 (48 GB, Ampere sm\_86), CUDA 12.9
**Config:** capacity = 1M, dim = 64, value\_type = float, batch = 1M keys, EvictStrategy = kCustomized

| Load Factor | THROUGHPUT Insert | THROUGHPUT Find | **MEMORY Insert** | **MEMORY Find** |
|:-----------:|:-----------------:|:---------------:|:-----------------:|:---------------:|
| 0.25 | 32.2 | 95.3 | **85.8** | **102.1** |
| 0.50 | 89.9 | 98.3 | **90.8** | **103.7** |
| 0.75 | 88.4 | 98.3 | **88.9** | **104.1** |
| 0.90 | 80.6 | 98.9 | **90.7** | **104.4** |
| 0.95 | 60.2 | 93.1 | **86.5** | **104.5** |
| 1.00 | 50.3 | 95.0 | **82.6** | **104.8** |

*(Throughput in Mops/s. Higher is better.)*

| | THROUGHPUT\_MODE | MEMORY\_MODE |
|---|---|---|
| **Top-K score retention** (fraction of ideal highest-scored keys present) | 96.49% | **99.73%** |
| **Insert at LF=1.0** | 50.3 Mops/s | **82.6 Mops/s (1.6×)** |
| **Find at LF=1.0** | 95.0 Mops/s | **104.8 Mops/s (1.1×)** |

Key observations:
- MEMORY\_MODE maintains **stable insert throughput (82–91 Mops/s)** across all load factors, while THROUGHPUT\_MODE degrades to 50 Mops/s at LF=1.0
- MEMORY\_MODE achieves **99.73% top-K score retention** (1,045,795 / 1,048,576 of the ideal highest-scored keys are present) vs 96.49% for single-bucket, meaning the eviction mechanism almost perfectly preserves the most valuable entries
- Find throughput is consistently ~7% higher in MEMORY\_MODE due to the two-pass early-exit optimization

### Limitations (Phase I)

**Init configuration constraints:**

| Parameter | Constraint | Reason |
|---|---|---|
| `init_capacity` | Must equal `max_capacity` | No auto-rehash in dual-bucket mode |
| `max_hbm_for_vectors` | Must be 0 (pure HBM only) | Hybrid HBM+HMEM not yet supported |
| `dim * sizeof(V)` | ≤ 896 bytes (dim ≤ 224 for float) | Fixed shared memory buffer size in lookup kernel |
| `capacity / max_bucket_size` | ≥ 2 | Two-choice addressing requires at least 2 buckets |

**Unsupported APIs (planned for Phase II):**

| API | Status |
|---|---|
| `insert_and_evict()` | Not supported — requires return-evicted-pair semantics |
| `find_or_insert()` | Not supported — requires atomic find-then-insert |
| `accum_or_assign()` | Not supported — requires read-modify-write |
| `assign_scores()` | Not supported |
| `assign_values()` | Not supported |
| `contains()` | Not supported |
| `erase()` | Not supported |
| `reserve()` | Not supported — no dynamic capacity change |

**Supported APIs:** `insert_or_assign()`, `find()`, `clear()`, `size()`, `export_batch()`, `export_batch_if()`
