### PR TITLE
[Opt] cache thread-local CUDA stream for lock acquisition kernels

### DIFF
--- a/include/merlin/group_lock.cuh
+++ b/include/merlin/group_lock.cuh
@@ -27,6 +27,20 @@ namespace nv {
 namespace merlin {
 
 /*
+ * Thread-local cached CUDA stream for lock acquisition kernels.
+ * Eliminates per-call cudaStreamCreate/Destroy overhead which causes
+ * CUDA driver contention when multiple threads acquire locks concurrently.
+ */
+inline cudaStream_t get_lock_stream() {
+  thread_local cudaStream_t stream = [] {
+    cudaStream_t s;
+    CUDA_CHECK(cudaStreamCreate(&s));
+    return s;
+  }();
+  return stream;
+}
+
+/*
  * Implementing a triple-group, mutex and relative lock guard for better E2E
  * performance:
  * - There are three roles: `inserter`, `updater`, and `reader`.
@@ -74,12 +88,10 @@ class group_shared_mutex {
       h_read_count_.fetch_add(1, std::memory_order_acq_rel);
       if (h_update_count_.load(std::memory_order_acquire) == 0) {
         {
-          cudaStream_t stream;
-          CUDA_CHECK(cudaStreamCreate(&stream));
+          cudaStream_t stream = get_lock_stream();
           group_lock::lock_read_kernel<<<1, 1, 0, stream>>>(d_update_count_,
                                                             d_read_count_);
           CUDA_CHECK(cudaStreamSynchronize(stream));
-          CUDA_CHECK(cudaStreamDestroy(stream));
         }
         break;
       }
@@ -99,12 +111,10 @@ class group_shared_mutex {
       h_update_count_.fetch_add(1, std::memory_order_acq_rel);
       if (h_read_count_.load(std::memory_order_acquire) == 0) {
         {
-          cudaStream_t stream;
-          CUDA_CHECK(cudaStreamCreate(&stream));
+          cudaStream_t stream = get_lock_stream();
           group_lock::lock_update_kernel<<<1, 1, 0, stream>>>(d_update_count_,
                                                               d_read_count_);
           CUDA_CHECK(cudaStreamSynchronize(stream));
-          CUDA_CHECK(cudaStreamDestroy(stream));
         }
         break;
       }
@@ -148,12 +158,10 @@ class group_shared_mutex {
     }
 
     {
-      cudaStream_t stream;
-      CUDA_CHECK(cudaStreamCreate(&stream));
+      cudaStream_t stream = get_lock_stream();
       group_lock::lock_update_read_kernel<<<1, 1, 0, stream>>>(
           d_update_count_, d_read_count_, d_unique_flag_);
       CUDA_CHECK(cudaStreamSynchronize(stream));
-      CUDA_CHECK(cudaStreamDestroy(stream));
     }
   }
 


### PR DESCRIPTION
- Replace per-call cudaStreamCreate/Destroy in lock_read(), lock_update(), and lock_update_read() with a thread_local cached stream. Eliminates CUDA driver contention when multiple threads acquire locks concurrently, which caused triple-group mode to underperform R/W lock in mixed workloads (0.93x) despite allowing concurrent updaters.

- **CI tests passed on the local machine.**

- Triple-Group vs R/W Lock Concurrency Benchmark                                                                                                                                             
                                                                                                                                                                                                      
  **Config:** dim=16, capacity=128M, HBM=16GB, λ=0.75, batch=64K, 200 batches/thread, H100 NVL                                                                                               
                                                                                                                                                                                                      
  ### With Stream Cache Optimization                                                                                                                                                                  
                                                                                                                                                                                                      
  | Workload | Threads | TG (B-KV/s) | RW (B-KV/s) | Speedup |                                                                                                                                      
  |:---------|:--------|------------:|------------:|--------:|                                                                                                                                        
  | Read-heavy | 8F/1U/1I | 1.451 | 1.408 | 1.03× |                                                                                                                                                 
  | Update-heavy | 4F/5U/1I | 1.675 | 0.523 | **3.21×** |
  | Insert-heavy | 4F/2U/4I | 0.551 | 0.459 | 1.20× |
  | Update-only | 1U | 1.054 | 1.046 | 1.01× |
  | Update-only | 2U | 1.613 | 1.125 | 1.43× |
  | Update-only | 5U | 2.279 | 0.591 | **3.86×** |
  | Update-only | 10U | 2.569 | 0.535 | **4.80×** |

  ### Before vs After Stream Cache

  | Workload | Before | After | Change |
  |:---------|-------:|------:|:-------|
  | Read-heavy | 1.02× | 1.03× | — |
  | Update-heavy | 0.93× | **3.21×** | fixed |
  | Insert-heavy | 0.98× | 1.20× | +22% |
  | Update-only 1U | 1.01× | 1.01× | — |
  | Update-only 2U | 1.33× | 1.43× | +8% |
  | Update-only 5U | 2.36× | **3.86×** | +64% |
  | Update-only 10U | 2.14× | **4.80×** | +124% |
