### PR TITLE
[Feat] Unlock scores for kCustomized mode: allow user-defined score 

### DIFF
--- a/include/merlin/core_kernels.cuh
+++ b/include/merlin/core_kernels.cuh
@@ -54,8 +54,8 @@ __global__ void release_locks(S* __restrict mutex, const size_t start,
   }
 }
 
-template <class K, class V, class S>
-__global__ void create_atomic_keys(Bucket<K, V, S>* __restrict buckets,
+template <class K, class V, class S, class SS = AtomicScore<S>>
+__global__ void create_atomic_keys(Bucket<K, V, S, SS>* __restrict buckets,
                                    const size_t start, const size_t end,
                                    const size_t bucket_max_size) {
   size_t tid = (blockIdx.x * blockDim.x) + threadIdx.x;
@@ -68,27 +68,27 @@ __global__ void create_atomic_keys(Bucket<K, V, S>* __restrict buckets,
   }
 }
 
-template <class K, class V, class S>
-__global__ void create_atomic_scores(Bucket<K, V, S>* __restrict buckets,
-                                     const size_t start, const size_t end,
-                                     const size_t bucket_max_size) {
+template <class K, class V, class S, class SS = AtomicScore<S>>
+__global__ void create_scores(Bucket<K, V, S, SS>* __restrict buckets,
+                              const size_t start, const size_t end,
+                              const size_t bucket_max_size) {
   size_t tid = (blockIdx.x * blockDim.x) + threadIdx.x;
   if (start + tid < end) {
     for (size_t i = 0; i < bucket_max_size; i++) {
-      new (buckets[start + tid].scores(i))
-          AtomicScore<S>{static_cast<S>(EMPTY_SCORE)};
+      score_store(buckets[start + tid].scores(i),
+                  static_cast<S>(EMPTY_SCORE));
     }
   }
 }
 
-template <class K, class V, class S>
-__global__ void allocate_bucket_vectors(Bucket<K, V, S>* __restrict buckets,
+template <class K, class V, class S, class SS = AtomicScore<S>>
+__global__ void allocate_bucket_vectors(Bucket<K, V, S, SS>* __restrict buckets,
                                         const size_t index, V* address) {
   buckets[index].vectors = address;
 }
 
-template <class K, class V, class S>
-__global__ void allocate_bucket_others(Bucket<K, V, S>* __restrict buckets,
+template <class K, class V, class S, class SS = AtomicScore<S>>
+__global__ void allocate_bucket_others(Bucket<K, V, S, SS>* __restrict buckets,
                                        size_t total_size_per_bucket,
                                        size_t num_of_buckets,
                                        const int start_index, uint8_t* address,
@@ -99,14 +99,14 @@ __global__ void allocate_bucket_others(Bucket<K, V, S>* __restrict buckets,
     buckets[index].digests_ = address;
     buckets[index].keys_ =
         reinterpret_cast<AtomicKey<K>*>(buckets[index].digests_ + reserve_size);
-    buckets[index].scores_ = reinterpret_cast<AtomicScore<S>*>(
+    buckets[index].scores_ = reinterpret_cast<SS*>(
         buckets[index].keys_ + bucket_max_size);
     address += total_size_per_bucket;
   }
 }
 
-template <class K, class V, class S>
-__global__ void get_bucket_others_address(Bucket<K, V, S>* __restrict buckets,
+template <class K, class V, class S, class SS = AtomicScore<S>>
+__global__ void get_bucket_others_address(Bucket<K, V, S, SS>* __restrict buckets,
                                           const int index, uint8_t** address) {
   *address = buckets[index].digests_;
 }
@@ -157,8 +157,8 @@ void realloc_host(P* ptr, size_t old_size, size_t new_size,
 }
 
 /* Initialize the buckets with index from start to end. */
-template <class K, class V, class S>
-void initialize_buckets(Table<K, V, S>** table, BaseAllocator* allocator,
+template <class K, class V, class S, class SS = AtomicScore<S>>
+void initialize_buckets(Table<K, V, S, SS>** table, BaseAllocator* allocator,
                         const size_t start, const size_t end) {
   /* As testing results show us, when the number of buckets is greater than
    * the 4 million the performance will drop significantly, we believe the
@@ -209,7 +209,7 @@ void initialize_buckets(Table<K, V, S>** table, BaseAllocator* allocator,
         size_t index = start + num_of_allocated_buckets + j;
         V* address =
             (*table)->slices[i] + j * (*table)->bucket_max_size * (*table)->dim;
-        allocate_bucket_vectors<K, V, S>
+        allocate_bucket_vectors<K, V, S, SS>
             <<<1, 1>>>((*table)->buckets, index, address);
         CUDA_CHECK(cudaDeviceSynchronize());
       } else {
@@ -218,7 +218,7 @@ void initialize_buckets(Table<K, V, S>** table, BaseAllocator* allocator,
         V* address = nullptr;
         CUDA_CHECK(cudaHostGetDevicePointer(&address, h_ptr, 0));
         size_t index = start + num_of_allocated_buckets + j;
-        allocate_bucket_vectors<K, V, S>
+        allocate_bucket_vectors<K, V, S, SS>
             <<<1, 1>>>((*table)->buckets, index, address);
       }
     }
@@ -229,7 +229,7 @@ void initialize_buckets(Table<K, V, S>** table, BaseAllocator* allocator,
   (*table)->num_of_memory_slices += num_of_memory_slices;
   uint32_t bucket_max_size = static_cast<uint32_t>((*table)->bucket_max_size);
   size_t bucket_memory_size =
-      bucket_max_size * (sizeof(AtomicKey<K>) + sizeof(AtomicScore<S>));
+      bucket_max_size * (sizeof(AtomicKey<K>) + sizeof(SS));
   // Align to the cache line size.
   constexpr uint32_t CACHE_LINE_SIZE = 128U / sizeof(uint8_t);
   uint32_t reserve_size =
@@ -249,7 +249,7 @@ void initialize_buckets(Table<K, V, S>** table, BaseAllocator* allocator,
         std::min(end - i, (*table)->num_of_buckets_per_alloc);
     allocator->alloc(MemoryType::Device, (void**)&(address),
                      bucket_memory_size * num_of_buckets);
-    allocate_bucket_others<K, V, S>
+    allocate_bucket_others<K, V, S, SS>
         <<<1, 1>>>((*table)->buckets, bucket_memory_size, num_of_buckets, i,
                    address, reserve_size, bucket_max_size);
   }
@@ -266,7 +266,7 @@ void initialize_buckets(Table<K, V, S>** table, BaseAllocator* allocator,
     const size_t block_size = 512;
     const size_t N = end - start + 1;
     const int grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-    create_atomic_keys<K, V, S><<<grid_size, block_size>>>(
+    create_atomic_keys<K, V, S, SS><<<grid_size, block_size>>>(
         (*table)->buckets, start, end, (*table)->bucket_max_size);
   }
 
@@ -274,15 +274,15 @@ void initialize_buckets(Table<K, V, S>** table, BaseAllocator* allocator,
     const size_t block_size = 512;
     const size_t N = end - start + 1;
     const int grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-    create_atomic_scores<K, V, S><<<grid_size, block_size>>>(
+    create_scores<K, V, S, SS><<<grid_size, block_size>>>(
         (*table)->buckets, start, end, (*table)->bucket_max_size);
   }
   CUDA_CHECK(cudaDeviceSynchronize());
   CudaCheckError();
 }
 
-template <class K, class V, class S>
-size_t get_slice_size(Table<K, V, S>** table) {
+template <class K, class V, class S, class SS = AtomicScore<S>>
+size_t get_slice_size(Table<K, V, S, SS>** table) {
   const size_t min_slice_size =
       (*table)->bucket_max_size * sizeof(V) * (*table)->dim;
   const size_t max_table_size = (*table)->max_size * sizeof(V) * (*table)->dim;
@@ -314,22 +314,22 @@ size_t get_slice_size(Table<K, V, S>** table) {
       or occurrence frequency or any thing for eviction.
    DIM: Vector dimension.
 */
-template <class K, class V, class S>
-void create_table(Table<K, V, S>** table, BaseAllocator* allocator,
+template <class K, class V, class S, class SS = AtomicScore<S>>
+void create_table(Table<K, V, S, SS>** table, BaseAllocator* allocator,
                   const size_t dim, const size_t init_size = 134217728,
                   const size_t max_size = std::numeric_limits<size_t>::max(),
                   const size_t max_hbm_for_vectors = 0,
                   const size_t bucket_max_size = 128,
                   const size_t num_of_buckets_per_alloc = 1,
                   const size_t tile_size = 32, const bool primary = true) {
-  allocator->alloc(MemoryType::Host, (void**)table, sizeof(Table<K, V, S>));
-  std::memset(*table, 0, sizeof(Table<K, V, S>));
+  allocator->alloc(MemoryType::Host, (void**)table, sizeof(Table<K, V, S, SS>));
+  std::memset(*table, 0, sizeof(Table<K, V, S, SS>));
   (*table)->dim = dim;
   (*table)->bucket_max_size = bucket_max_size;
   (*table)->max_size = std::max(init_size, max_size);
   (*table)->tile_size = tile_size;
   (*table)->is_pure_hbm = true;
-  (*table)->bytes_per_slice = get_slice_size<K, V, S>(table);
+  (*table)->bytes_per_slice = get_slice_size<K, V, S, SS>(table);
   (*table)->num_of_buckets_per_alloc = num_of_buckets_per_alloc;
 
   // The bucket number will be the minimum needed for saving memory if no
@@ -360,37 +360,37 @@ void create_table(Table<K, V, S>** table, BaseAllocator* allocator,
                         (*table)->buckets_num * sizeof(int)));
 
   allocator->alloc(MemoryType::Device, (void**)&((*table)->buckets),
-                   (*table)->buckets_num * sizeof(Bucket<K, V, S>));
+                   (*table)->buckets_num * sizeof(Bucket<K, V, S, SS>));
   CUDA_CHECK(cudaMemset((*table)->buckets, 0,
-                        (*table)->buckets_num * sizeof(Bucket<K, V, S>)));
+                        (*table)->buckets_num * sizeof(Bucket<K, V, S, SS>)));
 
-  initialize_buckets<K, V, S>(table, allocator, 0, (*table)->buckets_num);
+  initialize_buckets<K, V, S, SS>(table, allocator, 0, (*table)->buckets_num);
   CudaCheckError();
 }
 
 /* Double the capacity on storage, must be followed by calling the
  * rehash_kernel. */
-template <class K, class V, class S>
-void double_capacity(Table<K, V, S>** table, BaseAllocator* allocator) {
+template <class K, class V, class S, class SS = AtomicScore<S>>
+void double_capacity(Table<K, V, S, SS>** table, BaseAllocator* allocator) {
   realloc<Mutex*>(&((*table)->locks), (*table)->buckets_num * sizeof(Mutex),
                   (*table)->buckets_num * sizeof(Mutex) * 2, allocator);
   realloc<int*>(&((*table)->buckets_size), (*table)->buckets_num * sizeof(int),
                 (*table)->buckets_num * sizeof(int) * 2, allocator);
 
-  realloc<Bucket<K, V, S>*>(
-      &((*table)->buckets), (*table)->buckets_num * sizeof(Bucket<K, V, S>),
-      (*table)->buckets_num * sizeof(Bucket<K, V, S>) * 2, allocator);
+  realloc<Bucket<K, V, S, SS>*>(
+      &((*table)->buckets), (*table)->buckets_num * sizeof(Bucket<K, V, S, SS>),
+      (*table)->buckets_num * sizeof(Bucket<K, V, S, SS>) * 2, allocator);
 
-  initialize_buckets<K, V, S>(table, allocator, (*table)->buckets_num,
-                              (*table)->buckets_num * 2);
+  initialize_buckets<K, V, S, SS>(table, allocator, (*table)->buckets_num,
+                                  (*table)->buckets_num * 2);
 
   (*table)->capacity *= 2;
   (*table)->buckets_num *= 2;
 }
 
 /* free all of the resource of a Table. */
-template <class K, class V, class S>
-void destroy_table(Table<K, V, S>** table, BaseAllocator* allocator) {
+template <class K, class V, class S, class SS = AtomicScore<S>>
+void destroy_table(Table<K, V, S, SS>** table, BaseAllocator* allocator) {
   uint8_t** d_address = nullptr;
   CUDA_CHECK(cudaMalloc((void**)&d_address, sizeof(uint8_t*)));
   /* NOTICE: Only the buckets which index is the times of
@@ -399,7 +399,7 @@ void destroy_table(Table<K, V, S>** table, BaseAllocator* allocator) {
   for (int i = 0; i < (*table)->buckets_num;
        i += (*table)->num_of_buckets_per_alloc) {
     uint8_t* h_address;
-    get_bucket_others_address<K, V, S>
+    get_bucket_others_address<K, V, S, SS>
         <<<1, 1>>>((*table)->buckets, i, d_address);
     CUDA_CHECK(cudaMemcpy(&h_address, d_address, sizeof(uint8_t*),
                           cudaMemcpyDeviceToHost));
@@ -430,9 +430,10 @@ void destroy_table(Table<K, V, S>** table, BaseAllocator* allocator) {
   CudaCheckError();
 }
 
-template <class K, class V, class S, uint32_t TILE_SIZE = 4>
+template <class K, class V, class S, class SS = AtomicScore<S>,
+          uint32_t TILE_SIZE = 4>
 __forceinline__ __device__ void defragmentation_for_rehash(
-    Bucket<K, V, S>* __restrict bucket, uint32_t remove_pos,
+    Bucket<K, V, S, SS>* __restrict bucket, uint32_t remove_pos,
     const size_t bucket_max_size, const size_t buckets_num, const size_t dim) {
   uint32_t key_idx;
   size_t global_idx = 0;
@@ -460,10 +461,8 @@ __forceinline__ __device__ void defragmentation_for_rehash(
           (*(bucket->keys(key_idx))).load(cuda::std::memory_order_relaxed);
       bucket->digests(empty_pos)[0] = get_digest<K>(key);
       (*(bucket->keys(empty_pos))).store(key, cuda::std::memory_order_relaxed);
-      const S score =
-          (*(bucket->scores(key_idx))).load(cuda::std::memory_order_relaxed);
-      (*(bucket->scores(empty_pos)))
-          .store(score, cuda::std::memory_order_relaxed);
+      const S score = score_load(bucket->scores(key_idx));
+      score_store(bucket->scores(empty_pos), score);
       for (int j = 0; j < dim; j++) {
         bucket->vectors[empty_pos * dim + j] =
             bucket->vectors[key_idx * dim + j];
@@ -480,10 +479,11 @@ __forceinline__ __device__ void defragmentation_for_rehash(
   }
 }
 
-template <class K, class V, class S, uint32_t TILE_SIZE = 4>
+template <class K, class V, class S, class SS = AtomicScore<S>,
+          uint32_t TILE_SIZE = 4>
 __forceinline__ __device__ void move_key_to_new_bucket(
     cg::thread_block_tile<TILE_SIZE> g, int rank, const K& key, const S& score,
-    const V* __restrict vector, Bucket<K, V, S>* __restrict new_bucket,
+    const V* __restrict vector, Bucket<K, V, S, SS>* __restrict new_bucket,
     const size_t new_bkt_idx, const size_t new_start_idx,
     int* __restrict buckets_size, const size_t bucket_max_size,
     const size_t buckets_num, const size_t dim) {
@@ -505,8 +505,7 @@ __forceinline__ __device__ void move_key_to_new_bucket(
       if (rank == src_lane) {
         new_bucket->digests(key_pos)[0] = get_digest<K>(key);
         new_bucket->keys(key_pos)->store(key, cuda::std::memory_order_relaxed);
-        new_bucket->scores(key_pos)->store(score,
-                                           cuda::std::memory_order_relaxed);
+        score_store(new_bucket->scores(key_pos), score);
         atomicAdd(&(buckets_size[new_bkt_idx]), 1);
       }
       copy_vector<V, TILE_SIZE>(g, vector, new_bucket->vectors + key_pos * dim,
@@ -516,9 +515,10 @@ __forceinline__ __device__ void move_key_to_new_bucket(
   }
 }
 
-template <class K, class V, class S, uint32_t TILE_SIZE = 4>
+template <class K, class V, class S, class SS = AtomicScore<S>,
+          uint32_t TILE_SIZE = 4>
 __global__ void rehash_kernel_for_fast_mode(
-    const Table<K, V, S>* __restrict table, Bucket<K, V, S>* buckets,
+    const Table<K, V, S, SS>* __restrict table, Bucket<K, V, S, SS>* buckets,
     size_t N) {
   int* __restrict buckets_size = table->buckets_size;
   const size_t bucket_max_size = table->bucket_max_size;
@@ -535,7 +535,7 @@ __global__ void rehash_kernel_for_fast_mode(
 
   for (size_t t = tid; t < N; t += blockDim.x * gridDim.x) {
     uint32_t bkt_idx = t / TILE_SIZE;
-    Bucket<K, V, S>* bucket = (buckets + bkt_idx);
+    Bucket<K, V, S, SS>* bucket = (buckets + bkt_idx);
 
     lock<Mutex, TILE_SIZE>(g, table->locks[bkt_idx]);
     uint32_t key_idx = 0;
@@ -543,8 +543,7 @@ __global__ void rehash_kernel_for_fast_mode(
       key_idx = g.shfl(key_idx, 0);
       target_key =
           (bucket->keys(key_idx))->load(cuda::std::memory_order_relaxed);
-      target_score =
-          bucket->scores(key_idx)->load(cuda::std::memory_order_relaxed);
+      target_score = score_load(bucket->scores(key_idx));
       if (target_key != static_cast<K>(EMPTY_KEY) &&
           target_key != static_cast<K>(RECLAIM_KEY)) {
         const K hashed_key = Murmur3HashDevice(target_key);
@@ -552,7 +551,7 @@ __global__ void rehash_kernel_for_fast_mode(
         uint32_t new_bkt_idx = global_idx / bucket_max_size;
         if (new_bkt_idx != bkt_idx) {
           start_idx = get_start_position(global_idx, bucket_max_size);
-          move_key_to_new_bucket<K, V, S, TILE_SIZE>(
+          move_key_to_new_bucket<K, V, S, SS, TILE_SIZE>(
               g, rank, target_key, target_score,
               (bucket->vectors + key_idx * dim), buckets + new_bkt_idx,
               new_bkt_idx, start_idx, buckets_size, bucket_max_size,
@@ -563,7 +562,7 @@ __global__ void rehash_kernel_for_fast_mode(
                 ->store(static_cast<K>(EMPTY_KEY),
                         cuda::std::memory_order_relaxed);
             atomicSub(&(buckets_size[bkt_idx]), 1);
-            defragmentation_for_rehash<K, V, S, TILE_SIZE>(
+            defragmentation_for_rehash<K, V, S, SS, TILE_SIZE>(
                 bucket, key_idx, bucket_max_size, buckets_num / 2, dim);
             key_idx = 0;
           }
@@ -641,16 +640,16 @@ __global__ void read_kernel(const V* const* __restrict src, V* __restrict dst,
 }
 
 /* Clear all key-value in the table. */
-template <class K, class V, class S>
-__global__ void clear_kernel(Table<K, V, S>* __restrict table,
-                             Bucket<K, V, S>* buckets, size_t N) {
+template <class K, class V, class S, class SS = AtomicScore<S>>
+__global__ void clear_kernel(Table<K, V, S, SS>* __restrict table,
+                             Bucket<K, V, S, SS>* buckets, size_t N) {
   size_t tid = (blockIdx.x * blockDim.x) + threadIdx.x;
   const size_t bucket_max_size = table->bucket_max_size;
 
   for (size_t t = tid; t < N; t += blockDim.x * gridDim.x) {
     int key_idx = t % bucket_max_size;
     int bkt_idx = t / bucket_max_size;
-    Bucket<K, V, S>* bucket = &(buckets[bkt_idx]);
+    Bucket<K, V, S, SS>* bucket = &(buckets[bkt_idx]);
 
     bucket->digests(key_idx)[0] = empty_digest<K>();
     (bucket->keys(key_idx))
@@ -662,10 +661,11 @@ __global__ void clear_kernel(Table<K, V, S>* __restrict table,
 }
 
 /* Remove specified keys. */
-template <class K, class V, class S, uint32_t TILE_SIZE = 4>
-__global__ void remove_kernel(const Table<K, V, S>* __restrict table,
+template <class K, class V, class S, class SS = AtomicScore<S>,
+          uint32_t TILE_SIZE = 4>
+__global__ void remove_kernel(const Table<K, V, S, SS>* __restrict table,
                               const K* __restrict keys,
-                              Bucket<K, V, S>* __restrict buckets,
+                              Bucket<K, V, S, SS>* __restrict buckets,
                               int* __restrict buckets_size,
                               const size_t bucket_max_size,
                               const size_t buckets_num, size_t N) {
@@ -684,7 +684,7 @@ __global__ void remove_kernel(const Table<K, V, S>* __restrict table,
     size_t start_idx = 0;
     uint32_t tile_offset = 0;
 
-    Bucket<K, V, S>* bucket = get_key_position<K>(
+    Bucket<K, V, S, SS>* bucket = get_key_position<K>(
         buckets, find_key, bkt_idx, start_idx, buckets_num, bucket_max_size);
 
     unsigned found_vote = 0;
@@ -716,9 +716,8 @@ __global__ void remove_kernel(const Table<K, V, S>* __restrict table,
         (bucket->keys(key_pos))
             ->store(static_cast<K>(RECLAIM_KEY),
                     cuda::std::memory_order_relaxed);
-        (bucket->scores(key_pos))
-            ->store(static_cast<S>(EMPTY_SCORE),
-                    cuda::std::memory_order_relaxed);
+        score_store(bucket->scores(key_pos),
+                    static_cast<S>(EMPTY_SCORE));
         atomicSub(&buckets_size[bkt_idx], 1);
       }
       break;
@@ -727,13 +726,13 @@ __global__ void remove_kernel(const Table<K, V, S>* __restrict table,
 }
 
 /* Remove specified keys which match the Predict. */
-template <class K, class V, class S,
+template <class K, class V, class S, class SS = AtomicScore<S>,
           template <typename, typename> class PredFunctor,
           uint32_t TILE_SIZE = 1>
-__global__ void remove_kernel(const Table<K, V, S>* __restrict table,
+__global__ void remove_kernel(const Table<K, V, S, SS>* __restrict table,
                               const K pattern, const S threshold,
                               size_t* __restrict count,
-                              Bucket<K, V, S>* __restrict buckets,
+                              Bucket<K, V, S, SS>* __restrict buckets,
                               int* __restrict buckets_size,
                               const size_t bucket_max_size,
                               const size_t buckets_num, size_t N) {
@@ -745,7 +744,7 @@ __global__ void remove_kernel(const Table<K, V, S>* __restrict table,
     uint32_t bkt_idx = t;
     uint32_t key_pos = 0;
 
-    Bucket<K, V, S>* bucket = buckets + bkt_idx;
+    Bucket<K, V, S, SS>* bucket = buckets + bkt_idx;
 
     K current_key = 0;
     S current_score = 0;
@@ -753,8 +752,7 @@ __global__ void remove_kernel(const Table<K, V, S>* __restrict table,
     while (key_offset < bucket_max_size) {
       current_key =
           bucket->keys(key_offset)->load(cuda::std::memory_order_relaxed);
-      current_score =
-          bucket->scores(key_offset)->load(cuda::std::memory_order_relaxed);
+      current_score = score_load(bucket->scores(key_offset));
       if (!IS_RESERVED_KEY<K>(current_key)) {
         if (pred(current_key, current_score, pattern, threshold)) {
           atomicAdd(count, 1);
@@ -763,9 +761,8 @@ __global__ void remove_kernel(const Table<K, V, S>* __restrict table,
           (bucket->keys(key_pos))
               ->store(static_cast<K>(RECLAIM_KEY),
                       cuda::std::memory_order_relaxed);
-          (bucket->scores(key_pos))
-              ->store(static_cast<S>(EMPTY_SCORE),
-                      cuda::std::memory_order_relaxed);
+          score_store(bucket->scores(key_pos),
+                      static_cast<S>(EMPTY_SCORE));
           atomicSub(&buckets_size[bkt_idx], 1);
         } else {
           key_offset++;
@@ -777,11 +774,11 @@ __global__ void remove_kernel(const Table<K, V, S>* __restrict table,
   }
 }
 
-template <typename K, typename V, typename S, typename PredFunctor,
-          uint32_t GroupSize = 32>
+template <typename K, typename V, typename S, typename SS = AtomicScore<S>,
+          typename PredFunctor, uint32_t GroupSize = 32>
 __global__ void remove_kernel_v2(const uint64_t search_length,
                                  const uint64_t offset, PredFunctor pred,
-                                 Bucket<K, V, S>* buckets,
+                                 Bucket<K, V, S, SS>* buckets,
                                  int* __restrict buckets_size,
                                  const uint64_t bucket_capacity,
                                  const uint64_t dim, uint64_t* remove_counter) {
@@ -795,11 +792,10 @@ __global__ void remove_kernel_v2(const uint64_t search_length,
     uint64_t key_idx = (i + offset) % bucket_capacity;
 
     // May be different for threads within the same group.
-    Bucket<K, V, S>* bucket = buckets + bkt_idx;
+    Bucket<K, V, S, SS>* bucket = buckets + bkt_idx;
 
     const K key = bucket->keys(key_idx)->load(cuda::std::memory_order_relaxed);
-    const S score =
-        bucket->scores(key_idx)->load(cuda::std::memory_order_relaxed);
+    const S score = score_load(bucket->scores(key_idx));
     const V* value = bucket->vectors + key_idx * dim;
 
     bool match = pred.template operator()<GroupSize>(key, value, score, g);
@@ -819,8 +815,7 @@ __global__ void remove_kernel_v2(const uint64_t search_length,
       bucket->digests(key_idx)[0] = reclaim_digest<K>();
       bucket->keys(key_idx)->store(static_cast<K>(RECLAIM_KEY),
                                    cuda::std::memory_order_relaxed);
-      bucket->scores(key_idx)->store(static_cast<S>(EMPTY_SCORE),
-                                     cuda::std::memory_order_relaxed);
+      score_store(bucket->scores(key_idx), static_cast<S>(EMPTY_SCORE));
       if (bucket_capacity < GroupSize) {
         atomicSub(&buckets_size[bkt_idx], 1);
       }
@@ -841,9 +836,9 @@ inline std::tuple<size_t, size_t> dump_kernel_shared_memory_size(
   return std::make_tuple(block_size * sizeof(KVM<K, V, S>), block_size);
 }
 
-template <class K, class V, class S>
-__global__ void dump_kernel(const Table<K, V, S>* __restrict table,
-                            Bucket<K, V, S>* buckets, K* d_key,
+template <class K, class V, class S, class SS = AtomicScore<S>>
+__global__ void dump_kernel(const Table<K, V, S, SS>* __restrict table,
+                            Bucket<K, V, S, SS>* buckets, K* d_key,
                             V* __restrict d_val, S* __restrict d_score,
                             const size_t offset, const size_t search_length,
                             size_t* d_dump_counter) {
@@ -864,7 +859,7 @@ __global__ void dump_kernel(const Table<K, V, S>* __restrict table,
   __syncthreads();
 
   if (tid < search_length) {
-    Bucket<K, V, S>* const bucket{&buckets[(tid + offset) / bucket_max_size]};
+    Bucket<K, V, S, SS>* const bucket{&buckets[(tid + offset) / bucket_max_size]};
 
     const int key_idx{static_cast<int>((tid + offset) % bucket_max_size)};
     const K key{(bucket->keys(key_idx))->load(cuda::std::memory_order_relaxed)};
@@ -873,7 +868,7 @@ __global__ void dump_kernel(const Table<K, V, S>* __restrict table,
       size_t local_index{atomicAdd(&block_acc, 1)};
       block_tuples[local_index] = {
           key, &bucket->vectors[key_idx * dim],
-          bucket->scores(key_idx)->load(cuda::std::memory_order_relaxed)};
+          score_load(bucket->scores(key_idx))};
     }
   }
   __syncthreads();
@@ -898,10 +893,10 @@ __global__ void dump_kernel(const Table<K, V, S>* __restrict table,
 }
 
 /* Dump with score. */
-template <class K, class V, class S,
+template <class K, class V, class S, class SS = AtomicScore<S>,
           template <typename, typename> class PredFunctor>
-__global__ void dump_kernel(const Table<K, V, S>* __restrict table,
-                            Bucket<K, V, S>* buckets, const K pattern,
+__global__ void dump_kernel(const Table<K, V, S, SS>* __restrict table,
+                            Bucket<K, V, S, SS>* buckets, const K pattern,
                             const S threshold, K* d_key, V* __restrict d_val,
                             S* __restrict d_score, const size_t offset,
                             const size_t search_length,
@@ -927,11 +922,11 @@ __global__ void dump_kernel(const Table<K, V, S>* __restrict table,
   if (tid < search_length) {
     int bkt_idx = (tid + offset) / bucket_max_size;
     int key_idx = (tid + offset) % bucket_max_size;
-    Bucket<K, V, S>* bucket = &(buckets[bkt_idx]);
+    Bucket<K, V, S, SS>* bucket = &(buckets[bkt_idx]);
 
     const K key =
         (bucket->keys(key_idx))->load(cuda::std::memory_order_relaxed);
-    S score = bucket->scores(key_idx)->load(cuda::std::memory_order_relaxed);
+    S score = score_load(bucket->scores(key_idx));
 
     if (!IS_RESERVED_KEY<K>(key) && pred(key, score, pattern, threshold)) {
       size_t local_index = atomicAdd(&block_acc, 1);
@@ -964,10 +959,10 @@ __global__ void dump_kernel(const Table<K, V, S>* __restrict table,
   }
 }
 
-template <class K, class V, class S, class VecV,
+template <class K, class V, class S, class SS = AtomicScore<S>, class VecV,
           template <typename, typename> class PredFunctor, int TILE_SIZE>
-__global__ void dump_kernel_v2(const Table<K, V, S>* __restrict table,
-                               Bucket<K, V, S>* buckets, const K pattern,
+__global__ void dump_kernel_v2(const Table<K, V, S, SS>* __restrict table,
+                               Bucket<K, V, S, SS>* buckets, const K pattern,
                                const S threshold, K* d_key, V* __restrict d_val,
                                S* __restrict d_score, const size_t offset,
                                const size_t search_length,
@@ -983,11 +978,11 @@ __global__ void dump_kernel_v2(const Table<K, V, S>* __restrict table,
     size_t bkt_idx = (i + offset) / bucket_max_size;
     size_t key_idx = (i + offset) % bucket_max_size;
     size_t leading_key_idx = key_idx / TILE_SIZE * TILE_SIZE;
-    Bucket<K, V, S>* bucket = &(buckets[bkt_idx]);
+    Bucket<K, V, S, SS>* bucket = &(buckets[bkt_idx]);
 
     const K key =
         (bucket->keys(key_idx))->load(cuda::std::memory_order_relaxed);
-    S score = bucket->scores(key_idx)->load(cuda::std::memory_order_relaxed);
+    S score = score_load(bucket->scores(key_idx));
 
     bool match =
         (!IS_RESERVED_KEY<K>(key)) && pred(key, score, pattern, threshold);
@@ -1026,10 +1021,10 @@ __global__ void dump_kernel_v2(const Table<K, V, S>* __restrict table,
   }
 }
 
-template <typename K, typename V, typename S, typename PredFunctor,
-          uint32_t GroupSize = 32>
+template <typename K, typename V, typename S, typename SS = AtomicScore<S>,
+          typename PredFunctor, uint32_t GroupSize = 32>
 __global__ void dump_kernel(const uint64_t search_length, const uint64_t offset,
-                            PredFunctor pred, Bucket<K, V, S>* buckets,
+                            PredFunctor pred, Bucket<K, V, S, SS>* buckets,
                             const uint64_t bucket_capacity, const uint64_t dim,
                             K* __restrict__ out_keys, V* __restrict__ out_vals,
                             S* __restrict__ out_scores,
@@ -1044,11 +1039,10 @@ __global__ void dump_kernel(const uint64_t search_length, const uint64_t offset,
     uint64_t key_idx = (i + offset) % bucket_capacity;
 
     // May be different for threads within the same group.
-    Bucket<K, V, S>* bucket = buckets + bkt_idx;
+    Bucket<K, V, S, SS>* bucket = buckets + bkt_idx;
 
     const K key = bucket->keys(key_idx)->load(cuda::std::memory_order_relaxed);
-    const S score =
-        bucket->scores(key_idx)->load(cuda::std::memory_order_relaxed);
+    const S score = score_load(bucket->scores(key_idx));
     const V* value = bucket->vectors + key_idx * dim;
 
     bool match = pred.template operator()<GroupSize>(key, value, score, g);
@@ -1086,7 +1080,7 @@ __global__ void dump_kernel(const uint64_t search_length, const uint64_t offset,
         uint64_t cur_idx = (i / GroupSize) * GroupSize + r + offset;
         uint64_t cur_bkt_idx = cur_idx / bucket_capacity;
         uint64_t cur_key_idx = cur_idx % bucket_capacity;
-        Bucket<K, V, S>* cur_bucket = buckets + cur_bkt_idx;
+        Bucket<K, V, S, SS>* cur_bucket = buckets + cur_bkt_idx;
 
         for (int j = g.thread_rank(); j < dim; j += GroupSize) {
           out_vals[(group_offset + bias) * dim + j] =
@@ -1097,10 +1091,10 @@ __global__ void dump_kernel(const uint64_t search_length, const uint64_t offset,
   }
 }
 
-template <class K, class V, class S,
+template <class K, class V, class S, class SS = AtomicScore<S>,
           template <typename, typename> class PredFunctor>
-__global__ void size_if_kernel(const Table<K, V, S>* __restrict table,
-                               Bucket<K, V, S>* buckets, const K pattern,
+__global__ void size_if_kernel(const Table<K, V, S, SS>* __restrict table,
+                               Bucket<K, V, S, SS>* buckets, const K pattern,
                                const S threshold, size_t* d_counter) {
   extern __shared__ unsigned char s[];
 
@@ -1118,11 +1112,11 @@ __global__ void size_if_kernel(const Table<K, V, S>* __restrict table,
   __syncthreads();
 
   for (size_t i = tid; i < table->capacity; i += blockDim.x * gridDim.x) {
-    Bucket<K, V, S>* const bucket{&buckets[i / bucket_max_size]};
+    Bucket<K, V, S, SS>* const bucket{&buckets[i / bucket_max_size]};
 
     const int key_idx{static_cast<int>(i % bucket_max_size)};
     const K key{(bucket->keys(key_idx))->load(cuda::std::memory_order_relaxed)};
-    S score = bucket->scores(key_idx)->load(cuda::std::memory_order_relaxed);
+    S score = score_load(bucket->scores(key_idx));
 
     if ((!IS_RESERVED_KEY(key)) && pred(key, score, pattern, threshold)) {
       ++local_acc;
@@ -1136,11 +1130,11 @@ __global__ void size_if_kernel(const Table<K, V, S>* __restrict table,
   }
 }
 
-template <typename K, typename V, typename S, typename ExecutionFunc,
-          uint32_t GroupSize = 32>
+template <typename K, typename V, typename S, typename SS = AtomicScore<S>,
+          typename ExecutionFunc, uint32_t GroupSize = 32>
 __global__ void traverse_kernel(const uint64_t search_length,
                                 const uint64_t offset, ExecutionFunc f,
-                                Bucket<K, V, S>* buckets,
+                                Bucket<K, V, S, SS>* buckets,
                                 const uint64_t bucket_capacity,
                                 const uint64_t dim) {
   cg::thread_block_tile<GroupSize> g =
@@ -1153,7 +1147,7 @@ __global__ void traverse_kernel(const uint64_t search_length,
     uint64_t key_idx = (i + offset) % bucket_capacity;
 
     // May be different for threads within the same group.
-    Bucket<K, V, S>* bucket = buckets + bkt_idx;
+    Bucket<K, V, S, SS>* bucket = buckets + bkt_idx;
 
     const K key = bucket->keys(key_idx)->load(cuda::std::memory_order_relaxed);
     S* score = reinterpret_cast<S*>(bucket->scores(key_idx));
@@ -1231,13 +1225,14 @@ __global__ void compact_key_value_score_kernel(
   }
 }
 
-template <typename K, typename V, typename S, int Strategy = -1>
+template <typename K, typename V, typename S, typename SS = AtomicScore<S>,
+          int Strategy = -1>
 __global__ void lock_kernel_with_filter(
-    Bucket<K, V, S>* __restrict__ buckets, uint64_t const buckets_num,
+    Bucket<K, V, S, SS>* __restrict__ buckets, uint64_t const buckets_num,
     uint32_t bucket_capacity, uint32_t const dim, K const* __restrict__ keys,
     K** __restrict locked_keys_ptr, bool* __restrict succeed,
     S const* __restrict__ scores, const S global_epoch, uint64_t n) {
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using ScoreFunctor = ScoreFunctor<K, V, S, Strategy>;
   // Load `STRIDE` digests every time.
   constexpr uint32_t STRIDE = sizeof(VecD_Load) / sizeof(D);

--- a/include/merlin/core_kernels.cuh
+++ b/include/merlin/core_kernels.cuh
@@ -84,8 +84,7 @@ __global__ void create_scores(Bucket<K, V, S, SS>* __restrict buckets,
   size_t tid = (blockIdx.x * blockDim.x) + threadIdx.x;
   if (start + tid < end) {
     for (size_t i = 0; i < bucket_max_size; i++) {
-      score_store(buckets[start + tid].scores(i),
-                  static_cast<S>(EMPTY_SCORE));
+      new (buckets[start + tid].scores(i)) SS{static_cast<S>(EMPTY_SCORE)};
     }
   }
 }

--- a/include/merlin/core_kernels/accum_or_assign.cuh
+++ b/include/merlin/core_kernels/accum_or_assign.cuh
@@ -79,9 +79,10 @@ __global__ void write_with_accum_kernel(const V* __restrict delta_or_val,
  * update with IO operation. This kernel is
  * usually used for the pure HBM mode for better performance.
  */
-template <class K, class V, class S, int Strategy, uint32_t TILE_SIZE = 4>
+template <class K, class V, class S, class SS, int Strategy,
+          uint32_t TILE_SIZE = 4>
 __global__ void accum_or_assign_kernel_with_io(
-    const Table<K, V, S>* __restrict table, const size_t bucket_max_size,
+    const Table<K, V, S, SS>* __restrict table, const size_t bucket_max_size,
     const size_t buckets_num, const size_t dim, const K* __restrict keys,
     const V* __restrict value_or_deltas, const S* __restrict scores,
     const bool* __restrict accum_or_assigns, const S global_epoch,
@@ -111,7 +112,7 @@ __global__ void accum_or_assign_kernel_with_io(
     int src_lane = -1;
     K evicted_key;
 
-    Bucket<K, V, S>* bucket =
+    Bucket<K, V, S, SS>* bucket =
         get_key_position<K>(table->buckets, insert_key, bkt_idx, start_idx,
                             buckets_num, bucket_max_size);
 
@@ -173,20 +174,20 @@ __global__ void accum_or_assign_kernel_with_io(
   }
 }
 
-template <typename K, typename V, typename S, int Strategy>
+template <typename K, typename V, typename S, class SS, int Strategy>
 struct SelectAccumOrAssignKernelWithIO {
   static void execute_kernel(
       const float& load_factor, const int& block_size,
       const size_t bucket_max_size, const size_t buckets_num, const size_t dim,
       cudaStream_t& stream, const size_t& n,
-      const Table<K, V, S>* __restrict table, const K* __restrict keys,
+      const Table<K, V, S, SS>* __restrict table, const K* __restrict keys,
       const V* __restrict value_or_deltas, const S* __restrict scores,
       const bool* __restrict accum_or_assigns, const S global_epoch) {
     if (load_factor <= 0.75) {
       const unsigned int tile_size = 4;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      accum_or_assign_kernel_with_io<K, V, S, Strategy, tile_size>
+      accum_or_assign_kernel_with_io<K, V, S, SS, Strategy, tile_size>
           <<<grid_size, block_size, 0, stream>>>(
               table, bucket_max_size, buckets_num, dim, keys, value_or_deltas,
               scores, accum_or_assigns, global_epoch, N);
@@ -194,7 +195,7 @@ struct SelectAccumOrAssignKernelWithIO {
       const unsigned int tile_size = 32;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      accum_or_assign_kernel_with_io<K, V, S, Strategy, tile_size>
+      accum_or_assign_kernel_with_io<K, V, S, SS, Strategy, tile_size>
           <<<grid_size, block_size, 0, stream>>>(
               table, bucket_max_size, buckets_num, dim, keys, value_or_deltas,
               scores, accum_or_assigns, global_epoch, N);
@@ -203,9 +204,10 @@ struct SelectAccumOrAssignKernelWithIO {
   }
 };
 
-template <class K, class V, class S, int Strategy, uint32_t TILE_SIZE = 4>
+template <class K, class V, class S, class SS, int Strategy,
+          uint32_t TILE_SIZE = 4>
 __global__ void accum_or_assign_kernel(
-    const Table<K, V, S>* __restrict table, const size_t bucket_max_size,
+    const Table<K, V, S, SS>* __restrict table, const size_t bucket_max_size,
     const size_t buckets_num, const size_t dim, const K* __restrict keys,
     V** __restrict value_or_deltas, const S* __restrict scores,
     const bool* __restrict accum_or_assigns, int* __restrict src_offset,
@@ -234,7 +236,7 @@ __global__ void accum_or_assign_kernel(
     int src_lane = -1;
     K evicted_key;
 
-    Bucket<K, V, S>* bucket =
+    Bucket<K, V, S, SS>* bucket =
         get_key_position<K>(table->buckets, insert_key, bkt_idx, start_idx,
                             buckets_num, bucket_max_size);
 

--- a/include/merlin/core_kernels/accum_or_assign.cuh
+++ b/include/merlin/core_kernels/accum_or_assign.cuh
@@ -120,12 +120,12 @@ __global__ void accum_or_assign_kernel_with_io(
     const int bucket_size = buckets_size[bkt_idx];
     do {
       if (bucket_size < bucket_max_size) {
-        occupy_result = find_and_lock_when_vacant<K, V, S, TILE_SIZE>(
+        occupy_result = find_and_lock_when_vacant<K, V, S, SS, TILE_SIZE>(
             g, bucket, insert_key, insert_score, evicted_key, start_idx,
             key_pos, src_lane, bucket_max_size);
       } else {
         start_idx = (start_idx / TILE_SIZE) * TILE_SIZE;
-        occupy_result = find_and_lock_when_full<K, V, S, TILE_SIZE,
+        occupy_result = find_and_lock_when_full<K, V, S, SS, TILE_SIZE,
                                                 ScoreFunctor::LOCK_MEM_ORDER,
                                                 ScoreFunctor::UNLOCK_MEM_ORDER>(
             g, bucket, insert_key, insert_score, evicted_key, start_idx,
@@ -248,12 +248,12 @@ __global__ void accum_or_assign_kernel(
     const int bucket_size = buckets_size[bkt_idx];
     do {
       if (bucket_size < bucket_max_size) {
-        occupy_result = find_and_lock_when_vacant<K, V, S, TILE_SIZE>(
+        occupy_result = find_and_lock_when_vacant<K, V, S, SS, TILE_SIZE>(
             g, bucket, insert_key, insert_score, evicted_key, start_idx,
             key_pos, src_lane, bucket_max_size);
       } else {
         start_idx = (start_idx / TILE_SIZE) * TILE_SIZE;
-        occupy_result = find_and_lock_when_full<K, V, S, TILE_SIZE,
+        occupy_result = find_and_lock_when_full<K, V, S, SS, TILE_SIZE,
                                                 ScoreFunctor::LOCK_MEM_ORDER,
                                                 ScoreFunctor::UNLOCK_MEM_ORDER>(
             g, bucket, insert_key, insert_score, evicted_key, start_idx,

--- a/include/merlin/core_kernels/contains.cuh
+++ b/include/merlin/core_kernels/contains.cuh
@@ -21,9 +21,10 @@
 namespace nv {
 namespace merlin {
 
-template <typename K = uint64_t, typename V = float, typename S = uint64_t>
+template <typename K = uint64_t, typename V = float, typename S = uint64_t,
+          typename SS = AtomicScore<S>>
 struct ContainsKernelParams {
-  ContainsKernelParams(Bucket<K, V, S>* __restrict buckets_,
+  ContainsKernelParams(Bucket<K, V, S, SS>* __restrict buckets_,
                        size_t buckets_num_, uint32_t dim_,
                        const K* __restrict keys_, bool* __restrict founds_,
                        size_t n_)
@@ -33,7 +34,7 @@ struct ContainsKernelParams {
         keys(keys_),
         founds(founds_),
         n(n_) {}
-  Bucket<K, V, S>* __restrict buckets;
+  Bucket<K, V, S, SS>* __restrict buckets;
   size_t buckets_num;
   uint32_t dim;
   const K* __restrict keys;
@@ -42,8 +43,9 @@ struct ContainsKernelParams {
 };
 
 // Using 32 threads to deal with one key
-template <typename K = uint64_t, typename V = float, typename S = uint64_t>
-__global__ void contains_kernel_pipeline(Bucket<K, V, S>* buckets,
+template <typename K = uint64_t, typename V = float, typename S = uint64_t,
+          typename SS = AtomicScore<S>>
+__global__ void contains_kernel_pipeline(Bucket<K, V, S, SS>* buckets,
                                          const size_t buckets_num,
                                          const int dim,
                                          const K* __restrict keys,
@@ -82,7 +84,7 @@ __global__ void contains_kernel_pipeline(Bucket<K, V, S>* buckets,
     sm_target_digests[idx_block] = static_cast<uint32_t>(target_digest);
     int global_idx = hashed_key % (buckets_num * BUCKET_SIZE);
     int bkt_idx = global_idx / BUCKET_SIZE;
-    Bucket<K, V, S>* bucket = buckets + bkt_idx;
+    Bucket<K, V, S, SS>* bucket = buckets + bkt_idx;
     __pipeline_memcpy_async(sm_keys_ptr + idx_block, bucket->keys_addr(),
                             sizeof(K*));
     __pipeline_commit();
@@ -214,13 +216,13 @@ __global__ void contains_kernel_pipeline(Bucket<K, V, S>* buckets,
 
 }  // End function
 
-template <typename K, typename V, typename S>
+template <typename K, typename V, typename S, typename SS = AtomicScore<S>>
 struct LaunchPipelineContains {
-  static void launch_kernel(ContainsKernelParams<K, V, S>& params,
+  static void launch_kernel(ContainsKernelParams<K, V, S, SS>& params,
                             cudaStream_t& stream) {
     constexpr int BLOCK_SIZE = 128;
     // Using 32 threads to deal with one key
-    contains_kernel_pipeline<K, V, S>
+    contains_kernel_pipeline<K, V, S, SS>
         <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
             params.buckets, params.buckets_num, params.dim, params.keys,
             params.founds, params.n);
@@ -228,17 +230,18 @@ struct LaunchPipelineContains {
 };
 
 template <typename K, typename V, typename S = uint64_t,
-          typename ArchTag = Sm80>
+          typename SS = AtomicScore<S>, typename ArchTag = Sm80>
 struct SelectPipelineContainsKernel {
-  static void select_kernel(ContainsKernelParams<K, V, S>& params,
+  static void select_kernel(ContainsKernelParams<K, V, S, SS>& params,
                             cudaStream_t& stream) {
-    LaunchPipelineContains<K, V, S>::launch_kernel(params, stream);
+    LaunchPipelineContains<K, V, S, SS>::launch_kernel(params, stream);
   }
 };
 
-template <class K, class V, class S, uint32_t TILE_SIZE = 4>
-__global__ void contains_kernel(const Table<K, V, S>* __restrict table,
-                                Bucket<K, V, S>* buckets,
+template <class K, class V, class S, class SS = AtomicScore<S>,
+          uint32_t TILE_SIZE = 4>
+__global__ void contains_kernel(const Table<K, V, S, SS>* __restrict table,
+                                Bucket<K, V, S, SS>* buckets,
                                 const size_t bucket_max_size,
                                 const size_t buckets_num, const size_t dim,
                                 const K* __restrict keys,
@@ -260,7 +263,7 @@ __global__ void contains_kernel(const Table<K, V, S>* __restrict table,
     size_t bkt_idx = 0;
     size_t start_idx = 0;
 
-    Bucket<K, V, S>* bucket = get_key_position<K>(
+    Bucket<K, V, S, SS>* bucket = get_key_position<K>(
         buckets, find_key, bkt_idx, start_idx, buckets_num, bucket_max_size);
 
     const int bucket_size = buckets_size[bkt_idx];
@@ -278,26 +281,26 @@ __global__ void contains_kernel(const Table<K, V, S>* __restrict table,
   }
 }
 
-template <typename K, typename V, typename S>
+template <typename K, typename V, typename S, typename SS = AtomicScore<S>>
 struct SelectContainsKernel {
   static void execute_kernel(const float& load_factor, const int& block_size,
                              const size_t bucket_max_size,
                              const size_t buckets_num, const size_t dim,
                              cudaStream_t& stream, const size_t& n,
-                             const Table<K, V, S>* __restrict table,
-                             Bucket<K, V, S>* buckets, const K* __restrict keys,
+                             const Table<K, V, S, SS>* __restrict table,
+                             Bucket<K, V, S, SS>* buckets, const K* __restrict keys,
                              bool* __restrict found) {
     if (load_factor <= 0.75) {
       const unsigned int tile_size = 4;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      contains_kernel<K, V, S, tile_size><<<grid_size, block_size, 0, stream>>>(
+      contains_kernel<K, V, S, SS, tile_size><<<grid_size, block_size, 0, stream>>>(
           table, buckets, bucket_max_size, buckets_num, dim, keys, found, N);
     } else {
       const unsigned int tile_size = 16;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      contains_kernel<K, V, S, tile_size><<<grid_size, block_size, 0, stream>>>(
+      contains_kernel<K, V, S, SS, tile_size><<<grid_size, block_size, 0, stream>>>(
           table, buckets, bucket_max_size, buckets_num, dim, keys, found, N);
     }
     return;

--- a/include/merlin/core_kernels/contains.cuh
+++ b/include/merlin/core_kernels/contains.cuh
@@ -272,7 +272,7 @@ __global__ void contains_kernel(const Table<K, V, S, SS>* __restrict table,
     }
 
     OccupyResult occupy_result{OccupyResult::INITIAL};
-    occupy_result = find_without_lock<K, V, S, TILE_SIZE>(
+    occupy_result = find_without_lock<K, V, S, SS, TILE_SIZE>(
         g, bucket, find_key, start_idx, key_pos, src_lane, bucket_max_size);
 
     if (rank == src_lane) {

--- a/include/merlin/core_kernels/dual_bucket_upsert.cuh
+++ b/include/merlin/core_kernels/dual_bucket_upsert.cuh
@@ -553,7 +553,8 @@ __global__ void dual_bucket_pipeline_upsert_kernel_with_io(
                     cuda::std::memory_order_relaxed);
                 if (cas_ok) {
                   auto verify_score_ptr =
-                      BUCKET::scores(evict_keys_ptr, BUCKET_SIZE, min_pos_evict);
+                      reinterpret_cast<SS*>(BUCKET::scores(
+                          evict_keys_ptr, BUCKET_SIZE, min_pos_evict));
                   auto verify_score = score_load(verify_score_ptr);
                   if (verify_score <= min_score_global) {
                     if (expected_key == static_cast<K>(RECLAIM_KEY)) {

--- a/include/merlin/core_kernels/find_or_insert.cuh
+++ b/include/merlin/core_kernels/find_or_insert.cuh
@@ -23,13 +23,14 @@ namespace merlin {
 
 // Use 1 thread to deal with a KV-pair, including copying value.
 template <typename K = uint64_t, typename V = byte4, typename S = uint64_t,
-          typename VecV = byte16, uint32_t BLOCK_SIZE = 128, int Strategy = -1>
+          class SS = AtomicScore<S>, typename VecV = byte16,
+          uint32_t BLOCK_SIZE = 128, int Strategy = -1>
 __global__ void tlp_v1_find_or_insert_kernel_with_io(
-    Bucket<K, V, S>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
+    Bucket<K, V, S, SS>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
     const uint64_t buckets_num, uint32_t bucket_capacity, const uint32_t dim,
     const K* __restrict__ keys, VecV* __restrict__ values,
     S* __restrict__ scores, uint64_t n, const S global_epoch) {
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using CopyValue = CopyValueMultipleGroup<VecV, 1>;
   using ScoreFunctor = ScoreFunctor<K, V, S, Strategy>;
 
@@ -198,10 +199,7 @@ __global__ void tlp_v1_find_or_insert_kernel_with_io(
       if (result) {
         S* min_score_ptr =
             BUCKET::scores(bucket_keys_ptr, bucket_capacity, min_pos);
-        auto verify_score_ptr =
-            reinterpret_cast<AtomicScore<S>*>(min_score_ptr);
-        auto verify_score =
-            verify_score_ptr->load(cuda::std::memory_order_relaxed);
+        auto verify_score = *min_score_ptr;
         if (verify_score <= min_score) {
           key_pos = min_pos;
           ScoreFunctor::update_with_digest(bucket_keys_ptr, key_pos, scores,
@@ -239,14 +237,15 @@ __global__ void tlp_v1_find_or_insert_kernel_with_io(
 
 // Use 1 thread to deal with a KV-pair, including copying value.
 template <typename K = uint64_t, typename V = byte4, typename S = uint64_t,
-          typename VecV = byte16, uint32_t BLOCK_SIZE = 128,
-          uint32_t GROUP_SIZE = 16, int Strategy = -1>
+          class SS = AtomicScore<S>, typename VecV = byte16,
+          uint32_t BLOCK_SIZE = 128, uint32_t GROUP_SIZE = 16,
+          int Strategy = -1>
 __global__ void tlp_v2_find_or_insert_kernel_with_io(
-    Bucket<K, V, S>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
+    Bucket<K, V, S, SS>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
     const uint64_t buckets_num, uint32_t bucket_capacity, const uint32_t dim,
     const K* __restrict__ keys, VecV* __restrict__ values,
     S* __restrict__ scores, uint64_t n, const S global_epoch) {
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using CopyValue = CopyValueMultipleGroup<VecV, GROUP_SIZE>;
   using ScoreFunctor = ScoreFunctor<K, V, S, Strategy>;
 
@@ -423,10 +422,7 @@ __global__ void tlp_v2_find_or_insert_kernel_with_io(
       if (result) {
         S* min_score_ptr =
             BUCKET::scores(bucket_keys_ptr, bucket_capacity, min_pos);
-        auto verify_score_ptr =
-            reinterpret_cast<AtomicScore<S>*>(min_score_ptr);
-        auto verify_score =
-            verify_score_ptr->load(cuda::std::memory_order_relaxed);
+        auto verify_score = *min_score_ptr;
         if (verify_score <= min_score) {
           key_pos = min_pos;
           ScoreFunctor::update_with_digest(bucket_keys_ptr, key_pos, scores,
@@ -582,9 +578,10 @@ struct SharedMemoryManager_Pipeline_FindOrInsert {
 };
 
 template <typename K = uint64_t, typename V = byte4, typename S = uint64_t,
-          typename VecV = byte16, uint32_t BLOCK_SIZE = 128, int Strategy = -1>
+          class SS = AtomicScore<S>, typename VecV = byte16,
+          uint32_t BLOCK_SIZE = 128, int Strategy = -1>
 __global__ void pipeline_find_or_insert_kernel_with_io(
-    Bucket<K, V, S>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
+    Bucket<K, V, S, SS>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
     const uint64_t buckets_num, const uint32_t dim, const K* __restrict__ keys,
     VecV* __restrict__ values, S* __restrict__ scores, uint64_t n,
     const S global_epoch) {
@@ -595,7 +592,7 @@ __global__ void pipeline_find_or_insert_kernel_with_io(
   constexpr uint32_t Load_LEN = sizeof(VecD_Load) / sizeof(D);
   constexpr uint32_t Load_LEN_S = sizeof(byte16) / sizeof(S);
 
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using CopyValue = CopyValueMultipleGroup<VecV, GROUP_SIZE>;
   using SMM =
       SharedMemoryManager_Pipeline_FindOrInsert<K, V, S, VecV, BLOCK_SIZE,
@@ -827,10 +824,7 @@ __global__ void pipeline_find_or_insert_kernel_with_io(
               if (result) {
                 S* score_ptr = BUCKET::scores(bucket_keys_ptr, BUCKET_SIZE,
                                               min_pos_global);
-                auto verify_score_ptr =
-                    reinterpret_cast<AtomicScore<S>*>(score_ptr);
-                auto verify_score =
-                    verify_score_ptr->load(cuda::std::memory_order_relaxed);
+                auto verify_score = *score_ptr;
                 if (verify_score <= min_score_global) {
                   if (expected_key == static_cast<K>(RECLAIM_KEY)) {
                     occupy_result = OccupyResult::OCCUPIED_RECLAIMED;
@@ -953,10 +947,7 @@ __global__ void pipeline_find_or_insert_kernel_with_io(
           if (result) {
             S* score_ptr =
                 BUCKET::scores(bucket_keys_ptr, BUCKET_SIZE, min_pos_global);
-            auto verify_score_ptr =
-                reinterpret_cast<AtomicScore<S>*>(score_ptr);
-            auto verify_score =
-                verify_score_ptr->load(cuda::std::memory_order_relaxed);
+            auto verify_score = *score_ptr;
             if (verify_score <= min_score_global) {
               if (expected_key == static_cast<K>(RECLAIM_KEY)) {
                 atomicAdd(bucket_size_ptr, 1);
@@ -1049,10 +1040,11 @@ __global__ void pipeline_find_or_insert_kernel_with_io(
   }
 }
 
-template <typename K = uint64_t, typename V = float, typename S = uint64_t>
+template <typename K = uint64_t, typename V = float, typename S = uint64_t,
+          class SS = AtomicScore<S>>
 struct Params_FindOrInsert {
   Params_FindOrInsert(float load_factor_,
-                      Bucket<K, V, S>* __restrict__ buckets_,
+                      Bucket<K, V, S, SS>* __restrict__ buckets_,
                       int* buckets_size_, size_t buckets_num_,
                       uint32_t bucket_capacity_, uint32_t dim_,
                       const K* __restrict__ keys_, V* __restrict__ values_,
@@ -1069,7 +1061,7 @@ struct Params_FindOrInsert {
         n(n_),
         global_epoch(global_epoch_) {}
   float load_factor;
-  Bucket<K, V, S>* __restrict__ buckets;
+  Bucket<K, V, S, SS>* __restrict__ buckets;
   int* buckets_size;
   size_t buckets_num;
   uint32_t bucket_capacity;
@@ -1081,13 +1073,15 @@ struct Params_FindOrInsert {
   const S global_epoch;
 };
 
-template <typename K, typename V, typename S, typename VecV, int Strategy>
+template <typename K, typename V, typename S, class SS, typename VecV,
+          int Strategy>
 struct Launch_TLPv1_FindOrInsert {
-  using Params = Params_FindOrInsert<K, V, S>;
+  using Params = Params_FindOrInsert<K, V, S, SS>;
   inline static void launch_kernel(Params& params, cudaStream_t& stream) {
     constexpr int BLOCK_SIZE = 128;
     params.dim = params.dim * sizeof(V) / sizeof(VecV);
-    tlp_v1_find_or_insert_kernel_with_io<K, V, S, VecV, BLOCK_SIZE, Strategy>
+    tlp_v1_find_or_insert_kernel_with_io<K, V, S, SS, VecV, BLOCK_SIZE,
+                                         Strategy>
         <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
             params.buckets, params.buckets_size, params.buckets_num,
             params.bucket_capacity, params.dim, params.keys,
@@ -1096,9 +1090,10 @@ struct Launch_TLPv1_FindOrInsert {
   }
 };
 
-template <typename K, typename V, typename S, typename VecV, int Strategy>
+template <typename K, typename V, typename S, class SS, typename VecV,
+          int Strategy>
 struct Launch_TLPv2_FindOrInsert {
-  using Params = Params_FindOrInsert<K, V, S>;
+  using Params = Params_FindOrInsert<K, V, S, SS>;
   inline static void launch_kernel(Params& params, cudaStream_t& stream) {
     constexpr int BLOCK_SIZE = 128;
     const uint32_t value_size = params.dim * sizeof(V);
@@ -1106,7 +1101,7 @@ struct Launch_TLPv2_FindOrInsert {
 
     if (value_size <= 256) {
       constexpr int GROUP_SIZE = 8;
-      tlp_v2_find_or_insert_kernel_with_io<K, V, S, VecV, BLOCK_SIZE,
+      tlp_v2_find_or_insert_kernel_with_io<K, V, S, SS, VecV, BLOCK_SIZE,
                                            GROUP_SIZE, Strategy>
           <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
               params.buckets, params.buckets_size, params.buckets_num,
@@ -1115,7 +1110,7 @@ struct Launch_TLPv2_FindOrInsert {
               params.global_epoch);
     } else {
       constexpr int GROUP_SIZE = 16;
-      tlp_v2_find_or_insert_kernel_with_io<K, V, S, VecV, BLOCK_SIZE,
+      tlp_v2_find_or_insert_kernel_with_io<K, V, S, SS, VecV, BLOCK_SIZE,
                                            GROUP_SIZE, Strategy>
           <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
               params.buckets, params.buckets_size, params.buckets_num,
@@ -1126,9 +1121,10 @@ struct Launch_TLPv2_FindOrInsert {
   }
 };
 
-template <typename K, typename V, typename S, typename VecV, int Strategy>
+template <typename K, typename V, typename S, class SS, typename VecV,
+          int Strategy>
 struct Launch_Pipeline_FindOrInsert {
-  using Params = Params_FindOrInsert<K, V, S>;
+  using Params = Params_FindOrInsert<K, V, S, SS>;
   inline static void launch_kernel(Params& params, cudaStream_t& stream) {
     constexpr int BLOCK_SIZE = 128;
     constexpr uint32_t GROUP_SIZE = 32;
@@ -1141,7 +1137,8 @@ struct Launch_Pipeline_FindOrInsert {
     uint32_t shared_mem = SMM::total_size(params.dim);
     shared_mem =
         (shared_mem + sizeof(byte16) - 1) / sizeof(byte16) * sizeof(byte16);
-    pipeline_find_or_insert_kernel_with_io<K, V, S, VecV, BLOCK_SIZE, Strategy>
+    pipeline_find_or_insert_kernel_with_io<K, V, S, SS, VecV, BLOCK_SIZE,
+                                           Strategy>
         <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, shared_mem,
            stream>>>(params.buckets, params.buckets_size, params.buckets_num,
                      params.dim, params.keys,
@@ -1167,10 +1164,11 @@ struct ValueConfig_FindOrInsert<Sm70> {
   static constexpr uint32_t size_tlp_v2 = 128 * sizeof(byte4);
 };
 
-template <typename K, typename V, typename S, int Strategy, typename ArchTag>
+template <typename K, typename V, typename S, class SS, int Strategy,
+          typename ArchTag>
 struct KernelSelector_FindOrInsert {
   using ValueConfig = ValueConfig_FindOrInsert<ArchTag>;
-  using Params = Params_FindOrInsert<K, V, S>;
+  using Params = Params_FindOrInsert<K, V, S, SS>;
 
   static bool callable(bool unique_key, uint32_t bucket_size, uint32_t dim) {
     constexpr uint32_t MinBucketCap = sizeof(VecD_Load) / sizeof(D);
@@ -1191,23 +1189,23 @@ struct KernelSelector_FindOrInsert {
     auto launch_TLPv1 = [&]() {
       if (total_value_size % sizeof(byte16) == 0) {
         using VecV = byte16;
-        Launch_TLPv1_FindOrInsert<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_TLPv1_FindOrInsert<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else if (total_value_size % sizeof(byte8) == 0) {
         using VecV = byte8;
-        Launch_TLPv1_FindOrInsert<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_TLPv1_FindOrInsert<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else if (total_value_size % sizeof(byte4) == 0) {
         using VecV = byte4;
-        Launch_TLPv1_FindOrInsert<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_TLPv1_FindOrInsert<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else if (total_value_size % sizeof(byte2) == 0) {
         using VecV = byte2;
-        Launch_TLPv1_FindOrInsert<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_TLPv1_FindOrInsert<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else {
         using VecV = byte;
-        Launch_TLPv1_FindOrInsert<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_TLPv1_FindOrInsert<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       }
     };
@@ -1216,23 +1214,23 @@ struct KernelSelector_FindOrInsert {
     auto launch_TLPv2 = [&]() {
       if (total_value_size % sizeof(byte16) == 0) {
         using VecV = byte16;
-        Launch_TLPv2_FindOrInsert<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_TLPv2_FindOrInsert<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else if (total_value_size % sizeof(byte8) == 0) {
         using VecV = byte8;
-        Launch_TLPv2_FindOrInsert<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_TLPv2_FindOrInsert<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else if (total_value_size % sizeof(byte4) == 0) {
         using VecV = byte4;
-        Launch_TLPv2_FindOrInsert<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_TLPv2_FindOrInsert<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else if (total_value_size % sizeof(byte2) == 0) {
         using VecV = byte2;
-        Launch_TLPv2_FindOrInsert<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_TLPv2_FindOrInsert<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else {
         using VecV = byte;
-        Launch_TLPv2_FindOrInsert<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_TLPv2_FindOrInsert<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       }
     };
@@ -1241,23 +1239,23 @@ struct KernelSelector_FindOrInsert {
     auto launch_Pipeline = [&]() {
       if (total_value_size % sizeof(byte16) == 0) {
         using VecV = byte16;
-        Launch_Pipeline_FindOrInsert<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_Pipeline_FindOrInsert<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else if (total_value_size % sizeof(byte8) == 0) {
         using VecV = byte8;
-        Launch_Pipeline_FindOrInsert<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_Pipeline_FindOrInsert<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else if (total_value_size % sizeof(byte4) == 0) {
         using VecV = byte4;
-        Launch_Pipeline_FindOrInsert<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_Pipeline_FindOrInsert<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else if (total_value_size % sizeof(byte2) == 0) {
         using VecV = byte2;
-        Launch_Pipeline_FindOrInsert<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_Pipeline_FindOrInsert<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else {
         using VecV = byte;
-        Launch_Pipeline_FindOrInsert<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_Pipeline_FindOrInsert<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       }
     };
@@ -1299,9 +1297,10 @@ struct KernelSelector_FindOrInsert {
  * find or insert with IO operation. This kernel is
  * usually used for the pure HBM mode for better performance.
  */
-template <class K, class V, class S, int Strategy, uint32_t TILE_SIZE = 4>
+template <class K, class V, class S, class SS, int Strategy,
+          uint32_t TILE_SIZE = 4>
 __global__ void find_or_insert_kernel_with_io(
-    const Table<K, V, S>* __restrict table, Bucket<K, V, S>* buckets,
+    const Table<K, V, S, SS>* __restrict table, Bucket<K, V, S, SS>* buckets,
     const size_t bucket_max_size, const size_t buckets_num, const size_t dim,
     const K* __restrict keys, V* __restrict values, S* __restrict scores,
     const S global_epoch, const size_t N) {
@@ -1328,7 +1327,7 @@ __global__ void find_or_insert_kernel_with_io(
     int src_lane = -1;
     K evicted_key;
 
-    Bucket<K, V, S>* bucket =
+    Bucket<K, V, S, SS>* bucket =
         get_key_position<K>(buckets, find_or_insert_key, bkt_idx, start_idx,
                             buckets_num, bucket_max_size);
 
@@ -1380,21 +1379,21 @@ __global__ void find_or_insert_kernel_with_io(
   }
 }
 
-template <typename K, typename V, typename S, int Strategy>
+template <typename K, typename V, typename S, class SS, int Strategy>
 struct SelectFindOrInsertKernelWithIO {
   static void execute_kernel(const float& load_factor, const int& block_size,
                              const size_t bucket_max_size,
                              const size_t buckets_num, const size_t dim,
                              cudaStream_t& stream, const size_t& n,
-                             const Table<K, V, S>* __restrict table,
-                             Bucket<K, V, S>* buckets, const K* __restrict keys,
+                             const Table<K, V, S, SS>* __restrict table,
+                             Bucket<K, V, S, SS>* buckets, const K* __restrict keys,
                              V* __restrict values, S* __restrict scores,
                              const S global_epoch) {
     if (load_factor <= 0.75) {
       const unsigned int tile_size = 4;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      find_or_insert_kernel_with_io<K, V, S, Strategy, tile_size>
+      find_or_insert_kernel_with_io<K, V, S, SS, Strategy, tile_size>
           <<<grid_size, block_size, 0, stream>>>(
               table, buckets, bucket_max_size, buckets_num, dim, keys, values,
               scores, global_epoch, N);
@@ -1402,7 +1401,7 @@ struct SelectFindOrInsertKernelWithIO {
       const unsigned int tile_size = 32;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      find_or_insert_kernel_with_io<K, V, S, Strategy, tile_size>
+      find_or_insert_kernel_with_io<K, V, S, SS, Strategy, tile_size>
           <<<grid_size, block_size, 0, stream>>>(
               table, buckets, bucket_max_size, buckets_num, dim, keys, values,
               scores, global_epoch, N);
@@ -1413,15 +1412,16 @@ struct SelectFindOrInsertKernelWithIO {
 
 // Use 1 thread to deal with a KV-pair.
 template <typename K = uint64_t, typename V = byte4, typename S = uint64_t,
-          uint32_t BLOCK_SIZE = 128, int Strategy = -1>
+          class SS = AtomicScore<S>, uint32_t BLOCK_SIZE = 128,
+          int Strategy = -1>
 __global__ void find_or_insert_kernel_lock_key_hybrid(
-    Bucket<K, V, S>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
+    Bucket<K, V, S, SS>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
     const uint64_t buckets_num, uint32_t bucket_capacity, const uint32_t dim,
     const K* __restrict__ keys, V** __restrict__ value_ptrs,
     S* __restrict__ scores, K** __restrict__ key_ptrs,
     int* __restrict keys_index, bool* __restrict__ founds, uint64_t n,
     const S global_epoch) {
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using ScoreFunctor = ScoreFunctor<K, V, S, Strategy>;
 
   // bucket_capacity is a multiple of 4.
@@ -1604,10 +1604,7 @@ __global__ void find_or_insert_kernel_lock_key_hybrid(
       if (result) {
         S* min_score_ptr =
             BUCKET::scores(bucket_keys_ptr, bucket_capacity, min_pos);
-        auto verify_score_ptr =
-            reinterpret_cast<AtomicScore<S>*>(min_score_ptr);
-        auto verify_score =
-            verify_score_ptr->load(cuda::std::memory_order_relaxed);
+        auto verify_score = *min_score_ptr;
         if (verify_score <= min_score) {
           key_pos = min_pos;
           ScoreFunctor::update_with_digest(
@@ -1677,9 +1674,10 @@ __global__ void read_or_write_kernel_unlock_key(
 
 /* find or insert with the end-user specified score.
  */
-template <class K, class V, class S, int Strategy, uint32_t TILE_SIZE = 4>
+template <class K, class V, class S, class SS, int Strategy,
+          uint32_t TILE_SIZE = 4>
 __global__ void find_or_insert_kernel(
-    const Table<K, V, S>* __restrict table, Bucket<K, V, S>* buckets,
+    const Table<K, V, S, SS>* __restrict table, Bucket<K, V, S, SS>* buckets,
     const size_t bucket_max_size, const size_t buckets_num, const size_t dim,
     const K* __restrict keys, V** __restrict vectors, S* __restrict scores,
     bool* __restrict found, int* __restrict keys_index, const S global_epoch,
@@ -1706,7 +1704,7 @@ __global__ void find_or_insert_kernel(
     int src_lane = -1;
     K evicted_key;
 
-    Bucket<K, V, S>* bucket =
+    Bucket<K, V, S, SS>* bucket =
         get_key_position<K>(buckets, find_or_insert_key, bkt_idx, start_idx,
                             buckets_num, bucket_max_size);
 

--- a/include/merlin/core_kernels/find_or_insert.cuh
+++ b/include/merlin/core_kernels/find_or_insert.cuh
@@ -1335,12 +1335,12 @@ __global__ void find_or_insert_kernel_with_io(
     const int bucket_size = buckets_size[bkt_idx];
     do {
       if (bucket_size < bucket_max_size) {
-        occupy_result = find_and_lock_when_vacant<K, V, S, TILE_SIZE>(
+        occupy_result = find_and_lock_when_vacant<K, V, S, SS, TILE_SIZE>(
             g, bucket, find_or_insert_key, find_or_insert_score, evicted_key,
             start_idx, key_pos, src_lane, bucket_max_size);
       } else {
         start_idx = (start_idx / TILE_SIZE) * TILE_SIZE;
-        occupy_result = find_and_lock_when_full<K, V, S, TILE_SIZE,
+        occupy_result = find_and_lock_when_full<K, V, S, SS, TILE_SIZE,
                                                 ScoreFunctor::LOCK_MEM_ORDER,
                                                 ScoreFunctor::UNLOCK_MEM_ORDER>(
             g, bucket, find_or_insert_key, find_or_insert_score, evicted_key,
@@ -1716,12 +1716,12 @@ __global__ void find_or_insert_kernel(
     const int bucket_size = buckets_size[bkt_idx];
     do {
       if (bucket_size < bucket_max_size) {
-        occupy_result = find_and_lock_when_vacant<K, V, S, TILE_SIZE>(
+        occupy_result = find_and_lock_when_vacant<K, V, S, SS, TILE_SIZE>(
             g, bucket, find_or_insert_key, find_or_insert_score, evicted_key,
             start_idx, key_pos, src_lane, bucket_max_size);
       } else {
         start_idx = (start_idx / TILE_SIZE) * TILE_SIZE;
-        occupy_result = find_and_lock_when_full<K, V, S, TILE_SIZE,
+        occupy_result = find_and_lock_when_full<K, V, S, SS, TILE_SIZE,
                                                 ScoreFunctor::LOCK_MEM_ORDER,
                                                 ScoreFunctor::UNLOCK_MEM_ORDER>(
             g, bucket, find_or_insert_key, find_or_insert_score, evicted_key,

--- a/include/merlin/core_kernels/find_ptr_or_insert.cuh
+++ b/include/merlin/core_kernels/find_ptr_or_insert.cuh
@@ -23,14 +23,15 @@ namespace merlin {
 
 // Use 1 thread to deal with a KV-pair.
 template <typename K = uint64_t, typename V = byte4, typename S = uint64_t,
-          uint32_t BLOCK_SIZE = 128, int Strategy = -1>
+          class SS = AtomicScore<S>, uint32_t BLOCK_SIZE = 128,
+          int Strategy = -1>
 __global__ void find_or_insert_ptr_kernel_lock_key(
-    Bucket<K, V, S>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
+    Bucket<K, V, S, SS>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
     const uint64_t buckets_num, uint32_t bucket_capacity, const uint32_t dim,
     const K* __restrict__ keys, V** __restrict__ value_ptrs,
     S* __restrict__ scores, K** __restrict__ key_ptrs, uint64_t n,
     bool* __restrict__ founds, const S global_epoch) {
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using ScoreFunctor = ScoreFunctor<K, V, S, Strategy>;
 
   // bucket_capacity is a multiple of 4.
@@ -207,10 +208,7 @@ __global__ void find_or_insert_ptr_kernel_lock_key(
       if (result) {
         S* min_score_ptr =
             BUCKET::scores(bucket_keys_ptr, bucket_capacity, min_pos);
-        auto verify_score_ptr =
-            reinterpret_cast<AtomicScore<S>*>(min_score_ptr);
-        auto verify_score =
-            verify_score_ptr->load(cuda::std::memory_order_relaxed);
+        auto verify_score = *min_score_ptr;
         if (verify_score <= min_score) {
           key_pos = min_pos;
           ScoreFunctor::update_with_digest(bucket_keys_ptr, key_pos, scores,
@@ -261,9 +259,10 @@ __global__ void find_or_insert_ptr_kernel_unlock_key(const K* __restrict__ keys,
 
 /* find or insert with the end-user specified score.
  */
-template <class K, class V, class S, int Strategy, uint32_t TILE_SIZE = 4>
+template <class K, class V, class S, class SS, int Strategy,
+          uint32_t TILE_SIZE = 4>
 __global__ void find_ptr_or_insert_kernel(
-    const Table<K, V, S>* __restrict table, Bucket<K, V, S>* buckets,
+    const Table<K, V, S, SS>* __restrict table, Bucket<K, V, S, SS>* buckets,
     const size_t bucket_max_size, const size_t buckets_num, const size_t dim,
     const K* __restrict keys, V** __restrict vectors, S* __restrict scores,
     bool* __restrict found, const S global_epoch, const size_t N) {
@@ -289,7 +288,7 @@ __global__ void find_ptr_or_insert_kernel(
     int src_lane = -1;
     K evicted_key;
 
-    Bucket<K, V, S>* bucket =
+    Bucket<K, V, S, SS>* bucket =
         get_key_position<K>(buckets, find_or_insert_key, bkt_idx, start_idx,
                             buckets_num, bucket_max_size);
 
@@ -335,21 +334,21 @@ __global__ void find_ptr_or_insert_kernel(
   }
 }
 
-template <typename K, typename V, typename S, int Strategy>
+template <typename K, typename V, typename S, class SS, int Strategy>
 struct SelectFindOrInsertPtrKernel {
   static void execute_kernel(const float& load_factor, const int& block_size,
                              const size_t bucket_max_size,
                              const size_t buckets_num, const size_t dim,
                              cudaStream_t& stream, const size_t& n,
-                             const Table<K, V, S>* __restrict table,
-                             Bucket<K, V, S>* buckets, const K* __restrict keys,
+                             const Table<K, V, S, SS>* __restrict table,
+                             Bucket<K, V, S, SS>* buckets, const K* __restrict keys,
                              V** __restrict values, S* __restrict scores,
                              bool* __restrict found, const S global_epoch) {
     if (load_factor <= 0.5) {
       const unsigned int tile_size = 4;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      find_ptr_or_insert_kernel<K, V, S, Strategy, tile_size>
+      find_ptr_or_insert_kernel<K, V, S, SS, Strategy, tile_size>
           <<<grid_size, block_size, 0, stream>>>(
               table, buckets, bucket_max_size, buckets_num, dim, keys, values,
               scores, found, global_epoch, N);
@@ -357,7 +356,7 @@ struct SelectFindOrInsertPtrKernel {
       const unsigned int tile_size = 8;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      find_ptr_or_insert_kernel<K, V, S, Strategy, tile_size>
+      find_ptr_or_insert_kernel<K, V, S, SS, Strategy, tile_size>
           <<<grid_size, block_size, 0, stream>>>(
               table, buckets, bucket_max_size, buckets_num, dim, keys, values,
               scores, found, global_epoch, N);
@@ -365,7 +364,7 @@ struct SelectFindOrInsertPtrKernel {
       const unsigned int tile_size = 32;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      find_ptr_or_insert_kernel<K, V, S, Strategy, tile_size>
+      find_ptr_or_insert_kernel<K, V, S, SS, Strategy, tile_size>
           <<<grid_size, block_size, 0, stream>>>(
               table, buckets, bucket_max_size, buckets_num, dim, keys, values,
               scores, found, global_epoch, N);

--- a/include/merlin/core_kernels/find_ptr_or_insert.cuh
+++ b/include/merlin/core_kernels/find_ptr_or_insert.cuh
@@ -296,12 +296,12 @@ __global__ void find_ptr_or_insert_kernel(
     const int bucket_size = buckets_size[bkt_idx];
     do {
       if (bucket_size < bucket_max_size) {
-        occupy_result = find_and_lock_when_vacant<K, V, S, TILE_SIZE>(
+        occupy_result = find_and_lock_when_vacant<K, V, S, SS, TILE_SIZE>(
             g, bucket, find_or_insert_key, find_or_insert_score, evicted_key,
             start_idx, key_pos, src_lane, bucket_max_size);
       } else {
         start_idx = (start_idx / TILE_SIZE) * TILE_SIZE;
-        occupy_result = find_and_lock_when_full<K, V, S, TILE_SIZE,
+        occupy_result = find_and_lock_when_full<K, V, S, SS, TILE_SIZE,
                                                 ScoreFunctor::LOCK_MEM_ORDER,
                                                 ScoreFunctor::UNLOCK_MEM_ORDER>(
             g, bucket, find_or_insert_key, find_or_insert_score, evicted_key,

--- a/include/merlin/core_kernels/kernel_utils.cuh
+++ b/include/merlin/core_kernels/kernel_utils.cuh
@@ -557,8 +557,7 @@ struct ScoreFunctor<K, V, S, EvictStrategyInternal::kCustomized> {
       BUCKET* __restrict bucket, const int key_pos,
       const S* __restrict const input_scores, const int key_idx,
       const S& desired_score_when_missed, const bool new_insert) {
-    bucket->scores(key_pos)->store(desired_score_when_missed,
-                                   cuda::std::memory_order_relaxed);
+    score_store(bucket->scores(key_pos), desired_score_when_missed);
     return;
   }
 
@@ -580,8 +579,7 @@ struct ScoreFunctor<K, V, S, EvictStrategyInternal::kCustomized> {
       const S* __restrict const input_scores, const int key_idx,
       const S& epoch) {
     if (input_scores == nullptr) return;
-    bucket->scores(key_pos)->store(input_scores[key_idx],
-                                   cuda::std::memory_order_relaxed);
+    score_store(bucket->scores(key_pos), input_scores[key_idx]);
     return;
   }
 
@@ -606,9 +604,9 @@ __device__ __forceinline__ void copy_vector(
   }
 }
 
-template <class K, class V, class S>
-__forceinline__ __device__ Bucket<K, V, S>* get_key_position(
-    Bucket<K, V, S>* __restrict buckets, const K key, size_t& bkt_idx,
+template <class K, class V, class S, class SS = AtomicScore<S>>
+__forceinline__ __device__ Bucket<K, V, S, SS>* get_key_position(
+    Bucket<K, V, S, SS>* __restrict buckets, const K key, size_t& bkt_idx,
     size_t& start_idx, const size_t buckets_num, const size_t bucket_max_size) {
   const K hashed_key = Murmur3HashDevice(key);
   const size_t global_idx = hashed_key % (buckets_num * bucket_max_size);
@@ -625,9 +623,10 @@ __forceinline__ __device__ uint32_t get_start_position(
   return start_idx;
 }
 
-template <class K, class V, class S, uint32_t TILE_SIZE = 4>
+template <class K, class V, class S, class SS = AtomicScore<S>,
+          uint32_t TILE_SIZE = 4>
 __device__ __forceinline__ OccupyResult find_without_lock(
-    cg::thread_block_tile<TILE_SIZE> g, Bucket<K, V, S>* __restrict__ bucket,
+    cg::thread_block_tile<TILE_SIZE> g, Bucket<K, V, S, SS>* __restrict__ bucket,
     const K desired_key, const size_t start_idx, int& key_pos, int& src_lane,
     const size_t bucket_max_size) {
   K expected_key = static_cast<K>(EMPTY_KEY);
@@ -655,16 +654,16 @@ __device__ __forceinline__ OccupyResult find_without_lock(
   return OccupyResult::CONTINUE;
 }
 
-template <class K, class V, class S, uint32_t TILE_SIZE = 4>
+template <class K, class V, class S, class SS = AtomicScore<S>,
+          uint32_t TILE_SIZE = 4>
 __device__ __inline__ OccupyResult find_and_lock_when_vacant(
-    cg::thread_block_tile<TILE_SIZE> g, Bucket<K, V, S>* __restrict__ bucket,
-    const K desired_key, const S desired_score, K& evicted_key,
-    const size_t start_idx, int& key_pos, int& src_lane,
-    const size_t bucket_max_size) {
+    cg::thread_block_tile<TILE_SIZE> g,
+    Bucket<K, V, S, SS>* __restrict__ bucket, const K desired_key,
+    const S desired_score, K& evicted_key, const size_t start_idx,
+    int& key_pos, int& src_lane, const size_t bucket_max_size) {
   K expected_key = static_cast<K>(EMPTY_KEY);
 
   AtomicKey<K>* current_key;
-  AtomicScore<S>* current_score;
 
   K local_min_score_key = static_cast<K>(EMPTY_KEY);
 
@@ -727,19 +726,18 @@ __device__ __inline__ OccupyResult find_and_lock_when_vacant(
        tile_offset += TILE_SIZE) {
     key_pos = (start_idx + tile_offset + g.thread_rank()) % bucket_max_size;
 
-    current_score = bucket->scores(key_pos);
-
     // Step 4: record min score location.
-    temp_min_score_val = current_score->load(cuda::std::memory_order_relaxed);
+    // Skip slots with LOCKED_KEY to avoid torn reads for large S types.
+    expected_key =
+        bucket->keys(key_pos)->load(cuda::std::memory_order_relaxed);
+    if (expected_key == static_cast<K>(LOCKED_KEY) ||
+        expected_key == static_cast<K>(EMPTY_KEY))
+      continue;
+    temp_min_score_val = score_load(bucket->scores(key_pos));
     if (temp_min_score_val < local_min_score_val) {
-      expected_key =
-          bucket->keys(key_pos)->load(cuda::std::memory_order_relaxed);
-      if (expected_key != static_cast<K>(LOCKED_KEY) &&
-          expected_key != static_cast<K>(EMPTY_KEY)) {
-        local_min_score_key = expected_key;
-        local_min_score_val = temp_min_score_val;
-        local_min_score_pos = key_pos;
-      }
+      local_min_score_key = expected_key;
+      local_min_score_val = temp_min_score_val;
+      local_min_score_pos = key_pos;
     }
   }
   // Step 5: insert by evicting some one.
@@ -755,15 +753,15 @@ __device__ __inline__ OccupyResult find_and_lock_when_vacant(
     if (src_lane == g.thread_rank()) {
       // TBD: Here can be compare_exchange_weak. Do benchmark.
       current_key = bucket->keys(local_min_score_pos);
-      current_score = bucket->scores(local_min_score_pos);
       evicted_key = local_min_score_key;
       result = current_key->compare_exchange_strong(
           local_min_score_key, static_cast<K>(LOCKED_KEY),
           cuda::std::memory_order_relaxed, cuda::std::memory_order_relaxed);
 
       // Need to recover when fail.
-      if (result && (current_score->load(cuda::std::memory_order_relaxed) >
-                     global_min_score_val)) {
+      if (result &&
+          (score_load(bucket->scores(local_min_score_pos)) >
+           global_min_score_val)) {
         current_key->store(local_min_score_key,
                            cuda::std::memory_order_release);
         result = false;
@@ -781,18 +779,20 @@ __device__ __inline__ OccupyResult find_and_lock_when_vacant(
   return OccupyResult::CONTINUE;
 }
 
-template <class K, class V, class S, uint32_t TILE_SIZE,
-          cuda::std::memory_order LOCK_MEM_ORDER,
-          cuda::std::memory_order UNLOCK_MEM_ORDER>
+template <class K, class V, class S, class SS = AtomicScore<S>,
+          uint32_t TILE_SIZE = 4,
+          cuda::std::memory_order LOCK_MEM_ORDER =
+              cuda::std::memory_order_relaxed,
+          cuda::std::memory_order UNLOCK_MEM_ORDER =
+              cuda::std::memory_order_relaxed>
 __device__ __forceinline__ OccupyResult find_and_lock_when_full(
-    cg::thread_block_tile<TILE_SIZE> g, Bucket<K, V, S>* __restrict__ bucket,
-    const K desired_key, const S desired_score, K& evicted_key,
-    const size_t start_idx, int& key_pos, int& src_lane,
-    const size_t bucket_max_size) {
+    cg::thread_block_tile<TILE_SIZE> g,
+    Bucket<K, V, S, SS>* __restrict__ bucket, const K desired_key,
+    const S desired_score, K& evicted_key, const size_t start_idx,
+    int& key_pos, int& src_lane, const size_t bucket_max_size) {
   K expected_key = static_cast<K>(EMPTY_KEY);
 
   AtomicKey<K>* current_key;
-  AtomicScore<S>* current_score;
 
   K local_min_score_key = static_cast<K>(EMPTY_KEY);
 
@@ -830,12 +830,11 @@ __device__ __forceinline__ OccupyResult find_and_lock_when_full(
     key_pos = (start_idx + tile_offset + g.thread_rank()) % bucket_max_size;
 
     // Step 2: record min score location.
-    temp_min_score_val =
-        bucket->scores(key_pos)->load(cuda::std::memory_order_relaxed);
+    // Skip slots with LOCKED_KEY to avoid torn reads for large S types.
+    expected_key = bucket->keys(key_pos)->load(LOCK_MEM_ORDER);
+    if (expected_key == static_cast<K>(LOCKED_KEY)) continue;
+    temp_min_score_val = score_load(bucket->scores(key_pos));
     if (temp_min_score_val < local_min_score_val) {
-      while ((expected_key = bucket->keys(key_pos)->load(LOCK_MEM_ORDER)) ==
-             static_cast<K>(LOCKED_KEY)) {
-      };
       local_min_score_key = expected_key;
       local_min_score_val = temp_min_score_val;
       local_min_score_pos = key_pos;
@@ -855,15 +854,15 @@ __device__ __forceinline__ OccupyResult find_and_lock_when_full(
     if (src_lane == g.thread_rank()) {
       // TBD: Here can be compare_exchange_weak. Do benchmark.
       current_key = bucket->keys(local_min_score_pos);
-      current_score = bucket->scores(local_min_score_pos);
       evicted_key = local_min_score_key;
       result = current_key->compare_exchange_strong(
           local_min_score_key, static_cast<K>(LOCKED_KEY), LOCK_MEM_ORDER,
           cuda::std::memory_order_relaxed);
 
       // Need to recover when fail.
-      if (result && (current_score->load(cuda::std::memory_order_relaxed) >
-                     global_min_score_val)) {
+      if (result &&
+          (score_load(bucket->scores(local_min_score_pos)) >
+           global_min_score_val)) {
         current_key->store(local_min_score_key, UNLOCK_MEM_ORDER);
         result = false;
       }
@@ -880,9 +879,10 @@ __device__ __forceinline__ OccupyResult find_and_lock_when_full(
   return OccupyResult::CONTINUE;
 }
 
-template <class K, class V, class S, uint32_t TILE_SIZE>
+template <class K, class V, class S, class SS = AtomicScore<S>,
+          uint32_t TILE_SIZE = 4>
 __device__ __forceinline__ OccupyResult find_and_lock_for_update(
-    cg::thread_block_tile<TILE_SIZE> g, Bucket<K, V, S>* __restrict__ bucket,
+    cg::thread_block_tile<TILE_SIZE> g, Bucket<K, V, S, SS>* __restrict__ bucket,
     const K desired_key, const size_t start_idx, int& key_pos, int& src_lane,
     const size_t bucket_max_size) {
   K expected_key = static_cast<K>(EMPTY_KEY);

--- a/include/merlin/core_kernels/kernel_utils.cuh
+++ b/include/merlin/core_kernels/kernel_utils.cuh
@@ -570,8 +570,9 @@ struct ScoreFunctor<K, V, S, EvictStrategyInternal::kCustomized> {
     return input_scores[key_idx];
   }
 
+  template <class BucketT>
   __forceinline__ __device__ static void update(
-      BUCKET* __restrict bucket, const int key_pos,
+      BucketT* __restrict bucket, const int key_pos,
       const S* __restrict const input_scores, const int key_idx,
       const S& desired_score_when_missed, const bool new_insert) {
     score_store(bucket->scores(key_pos), desired_score_when_missed);
@@ -591,8 +592,9 @@ struct ScoreFunctor<K, V, S, EvictStrategyInternal::kCustomized> {
     __stcg(dst_score_ptr, desired_score_when_missed);
     return;
   }
+  template <class BucketT>
   __forceinline__ __device__ static void update_without_missed(
-      BUCKET* __restrict bucket, const int key_pos,
+      BucketT* __restrict bucket, const int key_pos,
       const S* __restrict const input_scores, const int key_idx,
       const S& epoch) {
     if (input_scores == nullptr) return;

--- a/include/merlin/core_kernels/lookup.cuh
+++ b/include/merlin/core_kernels/lookup.cuh
@@ -59,12 +59,14 @@ struct FoundFunctorV2 {
   int* __restrict missed_size;
 };
 
-template <typename K = uint64_t, typename V = float, typename S = uint64_t>
+template <typename K = uint64_t, typename V = float, typename S = uint64_t,
+          typename SS = AtomicScore<S>>
 struct LookupKernelParams {
-  LookupKernelParams(Bucket<K, V, S>* __restrict buckets_, size_t buckets_num_,
-                     uint32_t dim_, const K* __restrict keys_,
-                     V* __restrict values_, S* __restrict scores_,
-                     bool* __restrict founds_, size_t n_)
+  LookupKernelParams(Bucket<K, V, S, SS>* __restrict buckets_,
+                     size_t buckets_num_, uint32_t dim_,
+                     const K* __restrict keys_, V* __restrict values_,
+                     S* __restrict scores_, bool* __restrict founds_,
+                     size_t n_)
       : buckets(buckets_),
         buckets_num(buckets_num_),
         dim(dim_),
@@ -73,7 +75,7 @@ struct LookupKernelParams {
         scores(scores_),
         found_functor(founds_),
         n(n_) {}
-  Bucket<K, V, S>* __restrict buckets;
+  Bucket<K, V, S, SS>* __restrict buckets;
   size_t buckets_num;
   uint32_t dim;
   const K* __restrict keys;
@@ -83,9 +85,10 @@ struct LookupKernelParams {
   size_t n;
 };
 
-template <typename K = uint64_t, typename V = float, typename S = uint64_t>
+template <typename K = uint64_t, typename V = float, typename S = uint64_t,
+          typename SS = AtomicScore<S>>
 struct LookupKernelParamsV2 {
-  LookupKernelParamsV2(Bucket<K, V, S>* __restrict buckets_,
+  LookupKernelParamsV2(Bucket<K, V, S, SS>* __restrict buckets_,
                        size_t buckets_num_, uint32_t dim_,
                        const K* __restrict keys_, V* __restrict values_,
                        S* __restrict scores_, K* __restrict missed_keys_,
@@ -100,7 +103,7 @@ struct LookupKernelParamsV2 {
         found_functor(missed_keys_, missed_indices_, missed_size_),
         n(n_) {}
 
-  Bucket<K, V, S>* __restrict buckets;
+  Bucket<K, V, S, SS>* __restrict buckets;
   size_t buckets_num;
   uint32_t dim;
   const K* __restrict keys;
@@ -112,12 +115,12 @@ struct LookupKernelParamsV2 {
 
 // Using 32 threads to deal with one key
 template <typename K = uint64_t, typename V = float, typename S = uint64_t,
-          typename VecV = float4,
+          typename SS = AtomicScore<S>, typename VecV = float4,
           typename CopyScore = CopyScoreEmpty<S, K, 128>,
           typename CopyValue = CopyValueTwoGroup<VecV, 32>,
           typename FoundFunctor = FoundFunctorV1<K>, int VALUE_BUF = 56>
 __global__ void lookup_kernel_with_io_pipeline_v1(
-    Bucket<K, V, S>* buckets, const size_t buckets_num, const int dim,
+    Bucket<K, V, S, SS>* buckets, const size_t buckets_num, const int dim,
     const K* __restrict keys, VecV* __restrict values, S* __restrict scores,
     FoundFunctor found_functor, size_t n) {
   constexpr int GROUP_SIZE = 32;
@@ -158,7 +161,7 @@ __global__ void lookup_kernel_with_io_pipeline_v1(
     sm_target_digests[idx_block] = static_cast<uint32_t>(target_digest);
     int global_idx = hashed_key % (buckets_num * BUCKET_SIZE);
     int bkt_idx = global_idx / BUCKET_SIZE;
-    Bucket<K, V, S>* bucket = buckets + bkt_idx;
+    Bucket<K, V, S, SS>* bucket = buckets + bkt_idx;
     __pipeline_memcpy_async(sm_keys_ptr + idx_block, bucket->keys_addr(),
                             sizeof(K*));
     __pipeline_commit();
@@ -379,12 +382,12 @@ __global__ void lookup_kernel_with_io_pipeline_v1(
 
 // Using 16 threads to deal with one key
 template <typename K = uint64_t, typename V = float, typename S = uint64_t,
-          typename VecV = float4,
+          typename SS = AtomicScore<S>, typename VecV = float4,
           typename CopyScore = CopyScoreEmpty<S, K, 128>,
           typename CopyValue = CopyValueTwoGroup<VecV, 16>,
           typename FoundFunctor = FoundFunctorV1<K>, int VALUE_BUF = 32>
 __global__ void lookup_kernel_with_io_pipeline_v2(
-    Bucket<K, V, S>* buckets, const size_t buckets_num, const int dim,
+    Bucket<K, V, S, SS>* buckets, const size_t buckets_num, const int dim,
     const K* __restrict keys, VecV* __restrict values, S* __restrict scores,
     FoundFunctor found_functor, size_t n) {
   constexpr int GROUP_SIZE = 16;
@@ -425,7 +428,7 @@ __global__ void lookup_kernel_with_io_pipeline_v2(
     sm_target_digests[idx_block] = static_cast<uint32_t>(target_digest);
     int global_idx = hashed_key % (buckets_num * BUCKET_SIZE);
     int bkt_idx = global_idx / BUCKET_SIZE;
-    Bucket<K, V, S>* bucket = buckets + bkt_idx;
+    Bucket<K, V, S, SS>* bucket = buckets + bkt_idx;
     __pipeline_memcpy_async(sm_keys_ptr + idx_block, bucket->keys_addr(),
                             sizeof(K*));
     __pipeline_commit();
@@ -656,11 +659,12 @@ __global__ void lookup_kernel_with_io_pipeline_v2(
   }
 }  // End function
 
-template <typename K, typename V, typename S, typename CopyScore, typename VecV,
-          uint32_t ValueBufSize>
+template <typename K, typename V, typename S, typename SS, typename CopyScore,
+          typename VecV, uint32_t ValueBufSize>
 struct LaunchPipelineLookupV1 {
-  template <template <typename, typename, typename> typename LookupKernelParams>
-  static void launch_kernel(LookupKernelParams<K, V, S>& params,
+  template <template <typename, typename, typename, typename>
+            typename LookupKernelParams>
+  static void launch_kernel(LookupKernelParams<K, V, S, SS>& params,
                             cudaStream_t& stream) {
     constexpr int BLOCK_SIZE = 128;
     // Using 32 threads to deal with one key
@@ -669,7 +673,8 @@ struct LaunchPipelineLookupV1 {
     constexpr uint32_t VecSize = ValueBufSize / sizeof(VecV);
     if (params.dim > (GROUP_SIZE * 2)) {
       using CopyValue = CopyValueMultipleGroup<VecV, GROUP_SIZE>;
-      lookup_kernel_with_io_pipeline_v1<K, V, S, VecV, CopyScore, CopyValue,
+      lookup_kernel_with_io_pipeline_v1<K, V, S, SS, VecV, CopyScore,
+                                        CopyValue,
                                         decltype(params.found_functor), VecSize>
           <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
               params.buckets, params.buckets_num, params.dim, params.keys,
@@ -677,7 +682,8 @@ struct LaunchPipelineLookupV1 {
               params.found_functor, params.n);
     } else if (params.dim > GROUP_SIZE) {
       using CopyValue = CopyValueTwoGroup<VecV, GROUP_SIZE>;
-      lookup_kernel_with_io_pipeline_v1<K, V, S, VecV, CopyScore, CopyValue,
+      lookup_kernel_with_io_pipeline_v1<K, V, S, SS, VecV, CopyScore,
+                                        CopyValue,
                                         decltype(params.found_functor), VecSize>
           <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
               params.buckets, params.buckets_num, params.dim, params.keys,
@@ -685,7 +691,8 @@ struct LaunchPipelineLookupV1 {
               params.found_functor, params.n);
     } else {
       using CopyValue = CopyValueOneGroup<VecV, GROUP_SIZE>;
-      lookup_kernel_with_io_pipeline_v1<K, V, S, VecV, CopyScore, CopyValue,
+      lookup_kernel_with_io_pipeline_v1<K, V, S, SS, VecV, CopyScore,
+                                        CopyValue,
                                         decltype(params.found_functor), VecSize>
           <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
               params.buckets, params.buckets_num, params.dim, params.keys,
@@ -695,11 +702,12 @@ struct LaunchPipelineLookupV1 {
   }
 };
 
-template <typename K, typename V, typename S, typename CopyScore, typename VecV,
-          uint32_t ValueBufSize>
+template <typename K, typename V, typename S, typename SS, typename CopyScore,
+          typename VecV, uint32_t ValueBufSize>
 struct LaunchPipelineLookupV2 {
-  template <template <typename, typename, typename> typename LookupKernelParams>
-  static void launch_kernel(LookupKernelParams<K, V, S>& params,
+  template <template <typename, typename, typename, typename>
+            typename LookupKernelParams>
+  static void launch_kernel(LookupKernelParams<K, V, S, SS>& params,
                             cudaStream_t& stream) {
     constexpr int BLOCK_SIZE = 128;
     // Using 16 threads to deal with one key
@@ -708,7 +716,8 @@ struct LaunchPipelineLookupV2 {
     constexpr uint32_t VecSize = ValueBufSize / sizeof(VecV);
     if (params.dim > (GROUP_SIZE * 2)) {
       using CopyValue = CopyValueMultipleGroup<VecV, GROUP_SIZE>;
-      lookup_kernel_with_io_pipeline_v2<K, V, S, VecV, CopyScore, CopyValue,
+      lookup_kernel_with_io_pipeline_v2<K, V, S, SS, VecV, CopyScore,
+                                        CopyValue,
                                         decltype(params.found_functor), VecSize>
           <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
               params.buckets, params.buckets_num, params.dim, params.keys,
@@ -716,7 +725,8 @@ struct LaunchPipelineLookupV2 {
               params.found_functor, params.n);
     } else if (params.dim > GROUP_SIZE) {
       using CopyValue = CopyValueTwoGroup<VecV, GROUP_SIZE>;
-      lookup_kernel_with_io_pipeline_v2<K, V, S, VecV, CopyScore, CopyValue,
+      lookup_kernel_with_io_pipeline_v2<K, V, S, SS, VecV, CopyScore,
+                                        CopyValue,
                                         decltype(params.found_functor), VecSize>
           <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
               params.buckets, params.buckets_num, params.dim, params.keys,
@@ -724,7 +734,8 @@ struct LaunchPipelineLookupV2 {
               params.found_functor, params.n);
     } else {
       using CopyValue = CopyValueOneGroup<VecV, GROUP_SIZE>;
-      lookup_kernel_with_io_pipeline_v2<K, V, S, VecV, CopyScore, CopyValue,
+      lookup_kernel_with_io_pipeline_v2<K, V, S, SS, VecV, CopyScore,
+                                        CopyValue,
                                         decltype(params.found_functor), VecSize>
           <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
               params.buckets, params.buckets_num, params.dim, params.keys,
@@ -751,7 +762,7 @@ struct LookupValueBufConfig<Sm70> {
 };
 
 template <typename K, typename V, typename S = uint64_t,
-          typename ArchTag = Sm80>
+          typename SS = AtomicScore<S>, typename ArchTag = Sm80>
 struct SelectPipelineLookupKernelWithIO {
   using ValueBufConfig = LookupValueBufConfig<ArchTag>;
 
@@ -759,8 +770,9 @@ struct SelectPipelineLookupKernelWithIO {
     return ValueBufConfig::size_pipeline_v1;
   }
 
-  template <template <typename, typename, typename> typename LookupKernelParams>
-  static void select_kernel(LookupKernelParams<K, V, S>& params,
+  template <template <typename, typename, typename, typename>
+            typename LookupKernelParams>
+  static void select_kernel(LookupKernelParams<K, V, S, SS>& params,
                             cudaStream_t& stream) {
     constexpr int BUCKET_SIZE = 128;
     constexpr uint32_t buf_size_v1 = ValueBufConfig::size_pipeline_v1;
@@ -773,45 +785,45 @@ struct SelectPipelineLookupKernelWithIO {
       if (total_value_size <= buf_size_v1) {
         if (total_value_size % sizeof(float4) == 0) {
           using VecV = float4;
-          LaunchPipelineLookupV1<K, V, S, CopyScore, VecV,
+          LaunchPipelineLookupV1<K, V, S, SS, CopyScore, VecV,
                                  buf_size_v1>::launch_kernel(params, stream);
         } else if (total_value_size % sizeof(float2) == 0) {
           using VecV = float2;
-          LaunchPipelineLookupV1<K, V, S, CopyScore, VecV,
+          LaunchPipelineLookupV1<K, V, S, SS, CopyScore, VecV,
                                  buf_size_v1>::launch_kernel(params, stream);
         } else if (total_value_size % sizeof(float) == 0) {
           using VecV = float;
-          LaunchPipelineLookupV1<K, V, S, CopyScore, VecV,
+          LaunchPipelineLookupV1<K, V, S, SS, CopyScore, VecV,
                                  buf_size_v1>::launch_kernel(params, stream);
         } else if (total_value_size % sizeof(uint16_t) == 0) {
           using VecV = uint16_t;
-          LaunchPipelineLookupV1<K, V, S, CopyScore, VecV,
+          LaunchPipelineLookupV1<K, V, S, SS, CopyScore, VecV,
                                  buf_size_v1>::launch_kernel(params, stream);
         } else {
           using VecV = uint8_t;
-          LaunchPipelineLookupV1<K, V, S, CopyScore, VecV,
+          LaunchPipelineLookupV1<K, V, S, SS, CopyScore, VecV,
                                  buf_size_v1>::launch_kernel(params, stream);
         }
       } else {
         if (total_value_size % sizeof(float4) == 0) {
           using VecV = float4;
-          LaunchPipelineLookupV2<K, V, S, CopyScore, VecV,
+          LaunchPipelineLookupV2<K, V, S, SS, CopyScore, VecV,
                                  buf_size_v2>::launch_kernel(params, stream);
         } else if (total_value_size % sizeof(float2) == 0) {
           using VecV = float2;
-          LaunchPipelineLookupV2<K, V, S, CopyScore, VecV,
+          LaunchPipelineLookupV2<K, V, S, SS, CopyScore, VecV,
                                  buf_size_v2>::launch_kernel(params, stream);
         } else if (total_value_size % sizeof(float) == 0) {
           using VecV = float;
-          LaunchPipelineLookupV2<K, V, S, CopyScore, VecV,
+          LaunchPipelineLookupV2<K, V, S, SS, CopyScore, VecV,
                                  buf_size_v2>::launch_kernel(params, stream);
         } else if (total_value_size % sizeof(uint16_t) == 0) {
           using VecV = uint16_t;
-          LaunchPipelineLookupV2<K, V, S, CopyScore, VecV,
+          LaunchPipelineLookupV2<K, V, S, SS, CopyScore, VecV,
                                  buf_size_v2>::launch_kernel(params, stream);
         } else {
           using VecV = uint8_t;
-          LaunchPipelineLookupV2<K, V, S, CopyScore, VecV,
+          LaunchPipelineLookupV2<K, V, S, SS, CopyScore, VecV,
                                  buf_size_v2>::launch_kernel(params, stream);
         }
       }
@@ -820,45 +832,45 @@ struct SelectPipelineLookupKernelWithIO {
       if (total_value_size <= buf_size_v1) {
         if (total_value_size % sizeof(float4) == 0) {
           using VecV = float4;
-          LaunchPipelineLookupV1<K, V, S, CopyScore, VecV,
+          LaunchPipelineLookupV1<K, V, S, SS, CopyScore, VecV,
                                  buf_size_v1>::launch_kernel(params, stream);
         } else if (total_value_size % sizeof(float2) == 0) {
           using VecV = float2;
-          LaunchPipelineLookupV1<K, V, S, CopyScore, VecV,
+          LaunchPipelineLookupV1<K, V, S, SS, CopyScore, VecV,
                                  buf_size_v1>::launch_kernel(params, stream);
         } else if (total_value_size % sizeof(float) == 0) {
           using VecV = float;
-          LaunchPipelineLookupV1<K, V, S, CopyScore, VecV,
+          LaunchPipelineLookupV1<K, V, S, SS, CopyScore, VecV,
                                  buf_size_v1>::launch_kernel(params, stream);
         } else if (total_value_size % sizeof(uint16_t) == 0) {
           using VecV = uint16_t;
-          LaunchPipelineLookupV1<K, V, S, CopyScore, VecV,
+          LaunchPipelineLookupV1<K, V, S, SS, CopyScore, VecV,
                                  buf_size_v1>::launch_kernel(params, stream);
         } else {
           using VecV = uint8_t;
-          LaunchPipelineLookupV1<K, V, S, CopyScore, VecV,
+          LaunchPipelineLookupV1<K, V, S, SS, CopyScore, VecV,
                                  buf_size_v1>::launch_kernel(params, stream);
         }
       } else {
         if (total_value_size % sizeof(float4) == 0) {
           using VecV = float4;
-          LaunchPipelineLookupV2<K, V, S, CopyScore, VecV,
+          LaunchPipelineLookupV2<K, V, S, SS, CopyScore, VecV,
                                  buf_size_v2>::launch_kernel(params, stream);
         } else if (total_value_size % sizeof(float2) == 0) {
           using VecV = float2;
-          LaunchPipelineLookupV2<K, V, S, CopyScore, VecV,
+          LaunchPipelineLookupV2<K, V, S, SS, CopyScore, VecV,
                                  buf_size_v2>::launch_kernel(params, stream);
         } else if (total_value_size % sizeof(float) == 0) {
           using VecV = float;
-          LaunchPipelineLookupV2<K, V, S, CopyScore, VecV,
+          LaunchPipelineLookupV2<K, V, S, SS, CopyScore, VecV,
                                  buf_size_v2>::launch_kernel(params, stream);
         } else if (total_value_size % sizeof(uint16_t) == 0) {
           using VecV = uint16_t;
-          LaunchPipelineLookupV2<K, V, S, CopyScore, VecV,
+          LaunchPipelineLookupV2<K, V, S, SS, CopyScore, VecV,
                                  buf_size_v2>::launch_kernel(params, stream);
         } else {
           using VecV = uint8_t;
-          LaunchPipelineLookupV2<K, V, S, CopyScore, VecV,
+          LaunchPipelineLookupV2<K, V, S, SS, CopyScore, VecV,
                                  buf_size_v2>::launch_kernel(params, stream);
         }
       }
@@ -869,9 +881,10 @@ struct SelectPipelineLookupKernelWithIO {
 /* lookup with IO operation. This kernel is
  * usually used for the pure HBM mode for better performance.
  */
-template <class K, class V, class S, class FoundFunctor, uint32_t TILE_SIZE = 4>
+template <class K, class V, class S, class SS = AtomicScore<S>,
+          class FoundFunctor = FoundFunctorV1<K>, uint32_t TILE_SIZE = 4>
 __global__ void lookup_kernel_with_io(
-    const Table<K, V, S>* __restrict table, Bucket<K, V, S>* buckets,
+    const Table<K, V, S, SS>* __restrict table, Bucket<K, V, S, SS>* buckets,
     const size_t bucket_max_size, const size_t buckets_num, const size_t dim,
     const K* __restrict keys, V* __restrict values, S* __restrict scores,
     FoundFunctor found_functor, size_t N) {
@@ -894,7 +907,7 @@ __global__ void lookup_kernel_with_io(
     size_t bkt_idx = 0;
     size_t start_idx = 0;
 
-    Bucket<K, V, S>* bucket = get_key_position<K>(
+    Bucket<K, V, S, SS>* bucket = get_key_position<K>(
         buckets, find_key, bkt_idx, start_idx, buckets_num, bucket_max_size);
 
     const int bucket_size = buckets_size[bkt_idx];
@@ -913,8 +926,7 @@ __global__ void lookup_kernel_with_io(
       bool found = (rank == src_lane);
       if (found) {
         if (scores != nullptr) {
-          *(scores + key_idx) =
-              bucket->scores(key_pos)->load(cuda::std::memory_order_relaxed);
+          *(scores + key_idx) = score_load(bucket->scores(key_pos));
         }
       }
     }
@@ -924,21 +936,23 @@ __global__ void lookup_kernel_with_io(
   }
 }
 
-template <typename K, typename V, typename S, typename FoundFunctor>
+template <typename K, typename V, typename S, typename SS = AtomicScore<S>,
+          typename FoundFunctor = FoundFunctorV1<K>>
 struct SelectLookupKernelWithIOImpl {
   static void execute_kernel(const float& load_factor, const int& block_size,
                              const size_t bucket_max_size,
                              const size_t buckets_num, const size_t dim,
                              cudaStream_t& stream, const size_t& n,
-                             const Table<K, V, S>* __restrict table,
-                             Bucket<K, V, S>* buckets, const K* __restrict keys,
-                             V* __restrict values, S* __restrict scores,
+                             const Table<K, V, S, SS>* __restrict table,
+                             Bucket<K, V, S, SS>* buckets,
+                             const K* __restrict keys, V* __restrict values,
+                             S* __restrict scores,
                              const FoundFunctor& found_functor) {
     if (load_factor <= 0.75) {
       const unsigned int tile_size = 4;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      lookup_kernel_with_io<K, V, S, FoundFunctor, tile_size>
+      lookup_kernel_with_io<K, V, S, SS, FoundFunctor, tile_size>
           <<<grid_size, block_size, 0, stream>>>(
               table, buckets, bucket_max_size, buckets_num, dim, keys, values,
               scores, found_functor, N);
@@ -946,7 +960,7 @@ struct SelectLookupKernelWithIOImpl {
       const unsigned int tile_size = 16;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      lookup_kernel_with_io<K, V, S, FoundFunctor, tile_size>
+      lookup_kernel_with_io<K, V, S, SS, FoundFunctor, tile_size>
           <<<grid_size, block_size, 0, stream>>>(
               table, buckets, bucket_max_size, buckets_num, dim, keys, values,
               scores, found_functor, N);
@@ -955,38 +969,38 @@ struct SelectLookupKernelWithIOImpl {
   }
 };
 
-template <typename K, typename V, typename S>
+template <typename K, typename V, typename S, typename SS = AtomicScore<S>>
 struct SelectLookupKernelWithIO {
   static void execute_kernel(const float& load_factor, const int& block_size,
                              const size_t bucket_max_size,
                              const size_t buckets_num, const size_t dim,
                              cudaStream_t& stream, const size_t& n,
-                             const Table<K, V, S>* __restrict table,
-                             Bucket<K, V, S>* buckets, const K* __restrict keys,
-                             V* __restrict values, S* __restrict scores,
-                             bool* __restrict found) {
+                             const Table<K, V, S, SS>* __restrict table,
+                             Bucket<K, V, S, SS>* buckets,
+                             const K* __restrict keys, V* __restrict values,
+                             S* __restrict scores, bool* __restrict found) {
     FoundFunctorV1<K> found_functor(found);
-    SelectLookupKernelWithIOImpl<K, V, S, decltype(found_functor)>::
+    SelectLookupKernelWithIOImpl<K, V, S, SS, decltype(found_functor)>::
         execute_kernel(load_factor, block_size, bucket_max_size, buckets_num,
                        dim, stream, n, table, buckets, keys, values, scores,
                        found_functor);
   }
 };
 
-template <typename K, typename V, typename S>
+template <typename K, typename V, typename S, typename SS = AtomicScore<S>>
 struct SelectLookupKernelWithIOV2 {
   static void execute_kernel(const float& load_factor, const int& block_size,
                              const size_t bucket_max_size,
                              const size_t buckets_num, const size_t dim,
                              cudaStream_t& stream, const size_t& n,
-                             const Table<K, V, S>* __restrict table,
-                             Bucket<K, V, S>* buckets, const K* __restrict keys,
-                             V* __restrict values, S* __restrict scores,
-                             K* __restrict missed_keys,
+                             const Table<K, V, S, SS>* __restrict table,
+                             Bucket<K, V, S, SS>* buckets,
+                             const K* __restrict keys, V* __restrict values,
+                             S* __restrict scores, K* __restrict missed_keys,
                              int* __restrict missed_indices,
                              int* __restrict missed_size) {
     FoundFunctorV2<K> found_functor(missed_keys, missed_indices, missed_size);
-    SelectLookupKernelWithIOImpl<K, V, S, decltype(found_functor)>::
+    SelectLookupKernelWithIOImpl<K, V, S, SS, decltype(found_functor)>::
         execute_kernel(load_factor, block_size, bucket_max_size, buckets_num,
                        dim, stream, n, table, buckets, keys, values, scores,
                        found_functor);
@@ -995,13 +1009,14 @@ struct SelectLookupKernelWithIOV2 {
 
 // Use 1 thread to deal with a KV-pair, exculing copying value.
 template <typename K, typename V, typename S,
+          typename SS = AtomicScore<S>,
           typename FoundFunctor = FoundFunctorV1<K>>
 __device__ void tlp_lookup_kernel_hybrid_impl(
-    Bucket<K, V, S>* __restrict__ buckets, const uint64_t buckets_num,
+    Bucket<K, V, S, SS>* __restrict__ buckets, const uint64_t buckets_num,
     uint32_t bucket_capacity, const uint32_t dim, const K* __restrict__ keys,
     V** __restrict values, S* __restrict scores, int* __restrict dst_offset,
     FoundFunctor found_functor, uint64_t n) {
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
 
   uint32_t tx = threadIdx.x;
   uint32_t kv_idx = blockIdx.x * blockDim.x + tx;
@@ -1097,36 +1112,37 @@ __device__ void tlp_lookup_kernel_hybrid_impl(
   found_functor(kv_idx, key, false);
 }
 
-template <typename K, typename V, typename S>
+template <typename K, typename V, typename S, typename SS = AtomicScore<S>>
 __global__ void tlp_lookup_kernel_hybrid(
-    Bucket<K, V, S>* __restrict__ buckets, const uint64_t buckets_num,
+    Bucket<K, V, S, SS>* __restrict__ buckets, const uint64_t buckets_num,
     uint32_t bucket_capacity, const uint32_t dim, const K* __restrict__ keys,
     V** __restrict values, S* __restrict scores, int* __restrict dst_offset,
     bool* __restrict founds, uint64_t n) {
   FoundFunctorV1<K> found_functor(founds);
-  tlp_lookup_kernel_hybrid_impl<K, V, S, decltype(found_functor)>(
+  tlp_lookup_kernel_hybrid_impl<K, V, S, SS, decltype(found_functor)>(
       buckets, buckets_num, bucket_capacity, dim, keys, values, scores,
       dst_offset, found_functor, n);
 }
 
-template <typename K, typename V, typename S>
+template <typename K, typename V, typename S, typename SS = AtomicScore<S>>
 __global__ void tlp_lookup_kernel_hybrid(
-    Bucket<K, V, S>* __restrict__ buckets, const uint64_t buckets_num,
+    Bucket<K, V, S, SS>* __restrict__ buckets, const uint64_t buckets_num,
     uint32_t bucket_capacity, const uint32_t dim, const K* __restrict__ keys,
     V** __restrict values, S* __restrict scores, int* __restrict dst_offset,
     K* __restrict missed_keys, int* __restrict missed_indices,
     int* __restrict missed_size, uint64_t n) {
   FoundFunctorV2<K> found_functor(missed_keys, missed_indices, missed_size);
-  tlp_lookup_kernel_hybrid_impl<K, V, S, decltype(found_functor)>(
+  tlp_lookup_kernel_hybrid_impl<K, V, S, SS, decltype(found_functor)>(
       buckets, buckets_num, bucket_capacity, dim, keys, values, scores,
       dst_offset, found_functor, n);
 }
 
 /* lookup kernel.
  */
-template <class K, class V, class S, class FoundFunctor, uint32_t TILE_SIZE = 4>
+template <class K, class V, class S, class SS = AtomicScore<S>,
+          class FoundFunctor = FoundFunctorV1<K>, uint32_t TILE_SIZE = 4>
 __device__ void lookup_kernel_impl(
-    const Table<K, V, S>* __restrict table, Bucket<K, V, S>* buckets,
+    const Table<K, V, S, SS>* __restrict table, Bucket<K, V, S, SS>* buckets,
     const size_t bucket_max_size, const size_t buckets_num, const size_t dim,
     const K* __restrict keys, V** __restrict values, S* __restrict scores,
     FoundFunctor found_functor, int* __restrict dst_offset, size_t N) {
@@ -1147,7 +1163,7 @@ __device__ void lookup_kernel_impl(
     size_t bkt_idx = 0;
     size_t start_idx = 0;
 
-    Bucket<K, V, S>* bucket = get_key_position<K>(
+    Bucket<K, V, S, SS>* bucket = get_key_position<K>(
         buckets, find_key, bkt_idx, start_idx, buckets_num, bucket_max_size);
 
     const int bucket_size = buckets_size[bkt_idx];
@@ -1168,8 +1184,7 @@ __device__ void lookup_kernel_impl(
       if (rank == src_lane) {
         *(values + key_idx) = (bucket->vectors + key_pos * dim);
         if (scores != nullptr) {
-          *(scores + key_idx) =
-              bucket->scores(key_pos)->load(cuda::std::memory_order_relaxed);
+          *(scores + key_idx) = score_load(bucket->scores(key_pos));
         }
       }
     } else {
@@ -1184,29 +1199,31 @@ __device__ void lookup_kernel_impl(
   }
 }
 
-template <class K, class V, class S, uint32_t TILE_SIZE = 4>
-__global__ void lookup_kernel(const Table<K, V, S>* __restrict table,
-                              Bucket<K, V, S>* buckets,
+template <class K, class V, class S, class SS = AtomicScore<S>,
+          uint32_t TILE_SIZE = 4>
+__global__ void lookup_kernel(const Table<K, V, S, SS>* __restrict table,
+                              Bucket<K, V, S, SS>* buckets,
                               const size_t bucket_max_size,
                               const size_t buckets_num, const size_t dim,
                               const K* __restrict keys, V** __restrict values,
                               S* __restrict scores, bool* __restrict founds,
                               int* __restrict dst_offset, size_t N) {
   FoundFunctorV1<K> found_functor(founds);
-  lookup_kernel_impl<K, V, S, decltype(found_functor), TILE_SIZE>(
+  lookup_kernel_impl<K, V, S, SS, decltype(found_functor), TILE_SIZE>(
       table, buckets, bucket_max_size, buckets_num, dim, keys, values, scores,
       found_functor, dst_offset, N);
 }
 
-template <class K, class V, class S, uint32_t TILE_SIZE = 4>
+template <class K, class V, class S, class SS = AtomicScore<S>,
+          uint32_t TILE_SIZE = 4>
 __global__ void lookup_kernel(
-    const Table<K, V, S>* __restrict table, Bucket<K, V, S>* buckets,
+    const Table<K, V, S, SS>* __restrict table, Bucket<K, V, S, SS>* buckets,
     const size_t bucket_max_size, const size_t buckets_num, const size_t dim,
     const K* __restrict keys, V** __restrict values, S* __restrict scores,
     K* __restrict missed_keys, int* __restrict missed_indices,
     int* __restrict missed_size, int* __restrict dst_offset, size_t N) {
   FoundFunctorV2<K> found_functor(missed_keys, missed_indices, missed_size);
-  lookup_kernel_impl<K, V, S, decltype(found_functor), TILE_SIZE>(
+  lookup_kernel_impl<K, V, S, SS, decltype(found_functor), TILE_SIZE>(
       table, buckets, bucket_max_size, buckets_num, dim, keys, values, scores,
       found_functor, dst_offset, N);
 }

--- a/include/merlin/core_kernels/lookup.cuh
+++ b/include/merlin/core_kernels/lookup.cuh
@@ -916,7 +916,7 @@ __global__ void lookup_kernel_with_io(
     }
 
     OccupyResult occupy_result{OccupyResult::INITIAL};
-    occupy_result = find_without_lock<K, V, S, TILE_SIZE>(
+    occupy_result = find_without_lock<K, V, S, SS, TILE_SIZE>(
         g, bucket, find_key, start_idx, key_pos, src_lane, bucket_max_size);
 
     bool found = occupy_result == OccupyResult::DUPLICATE;
@@ -1176,7 +1176,7 @@ __device__ void lookup_kernel_impl(
     }
 
     OccupyResult occupy_result{OccupyResult::INITIAL};
-    occupy_result = find_without_lock<K, V, S, TILE_SIZE>(
+    occupy_result = find_without_lock<K, V, S, SS, TILE_SIZE>(
         g, bucket, find_key, start_idx, key_pos, src_lane, bucket_max_size);
 
     bool found = (occupy_result == OccupyResult::DUPLICATE);

--- a/include/merlin/core_kernels/lookup_ptr.cuh
+++ b/include/merlin/core_kernels/lookup_ptr.cuh
@@ -22,13 +22,14 @@ namespace nv {
 namespace merlin {
 
 // Use 1 thread to deal with a KV-pair, including copying value.
-template <typename K, typename V, typename S, int Strategy>
+template <typename K, typename V, typename S, int Strategy,
+          typename SS = AtomicScore<S>>
 __global__ void tlp_lookup_ptr_kernel_with_filter(
-    Bucket<K, V, S>* __restrict__ buckets, const uint64_t buckets_num,
+    Bucket<K, V, S, SS>* __restrict__ buckets, const uint64_t buckets_num,
     uint32_t bucket_capacity, const uint32_t dim, const K* __restrict__ keys,
     V** __restrict values, S* __restrict scores, bool* __restrict founds,
     uint64_t n, bool update_score, const S global_epoch) {
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using ScoreFunctor = ScoreFunctor<K, V, S, Strategy>;
   // Load `STRIDE` digests every time.
   constexpr uint32_t STRIDE = sizeof(VecD_Load) / sizeof(D);
@@ -154,9 +155,10 @@ WRITE_BACK:
 /* lookup with IO operation. This kernel is
  * usually used for the pure HBM mode for better performance.
  */
-template <class K, class V, class S, uint32_t TILE_SIZE = 4>
-__global__ void lookup_ptr_kernel(const Table<K, V, S>* __restrict table,
-                                  Bucket<K, V, S>* buckets,
+template <class K, class V, class S, class SS = AtomicScore<S>,
+          uint32_t TILE_SIZE = 4>
+__global__ void lookup_ptr_kernel(const Table<K, V, S, SS>* __restrict table,
+                                  Bucket<K, V, S, SS>* buckets,
                                   const size_t bucket_max_size,
                                   const size_t buckets_num, const size_t dim,
                                   const K* __restrict keys,
@@ -175,7 +177,7 @@ __global__ void lookup_ptr_kernel(const Table<K, V, S>* __restrict table,
     OccupyResult occupy_result{OccupyResult::INITIAL};
     int key_pos = -1;
     int src_lane = -1;
-    Bucket<K, V, S>* bucket{nullptr};
+    Bucket<K, V, S, SS>* bucket{nullptr};
     if (!IS_RESERVED_KEY<K>(find_key)) {
       size_t bkt_idx = 0;
       size_t start_idx = 0;
@@ -202,8 +204,7 @@ __global__ void lookup_ptr_kernel(const Table<K, V, S>* __restrict table,
       if (found_) {
         values[key_idx] = bucket->vectors + key_pos * dim;
         if (scores != nullptr) {
-          *(scores + key_idx) =
-              bucket->scores(key_pos)->load(cuda::std::memory_order_relaxed);
+          *(scores + key_idx) = score_load(bucket->scores(key_pos));
         }
       } else {
         values[key_idx] = nullptr;
@@ -212,21 +213,21 @@ __global__ void lookup_ptr_kernel(const Table<K, V, S>* __restrict table,
   }
 }
 
-template <typename K, typename V, typename S>
+template <typename K, typename V, typename S, typename SS = AtomicScore<S>>
 struct SelectLookupPtrKernel {
   static void execute_kernel(const float& load_factor, const int& block_size,
                              const size_t bucket_max_size,
                              const size_t buckets_num, const size_t dim,
                              cudaStream_t& stream, const size_t& n,
-                             const Table<K, V, S>* __restrict table,
-                             Bucket<K, V, S>* buckets, const K* __restrict keys,
-                             V** __restrict values, S* __restrict scores,
-                             bool* __restrict found) {
+                             const Table<K, V, S, SS>* __restrict table,
+                             Bucket<K, V, S, SS>* buckets,
+                             const K* __restrict keys, V** __restrict values,
+                             S* __restrict scores, bool* __restrict found) {
     if (load_factor <= 0.75) {
       const unsigned int tile_size = 4;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      lookup_ptr_kernel<K, V, S, tile_size>
+      lookup_ptr_kernel<K, V, S, SS, tile_size>
           <<<grid_size, block_size, 0, stream>>>(
               table, buckets, bucket_max_size, buckets_num, dim, keys, values,
               scores, found, N);
@@ -234,7 +235,7 @@ struct SelectLookupPtrKernel {
       const unsigned int tile_size = 16;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      lookup_ptr_kernel<K, V, S, tile_size>
+      lookup_ptr_kernel<K, V, S, SS, tile_size>
           <<<grid_size, block_size, 0, stream>>>(
               table, buckets, bucket_max_size, buckets_num, dim, keys, values,
               scores, found, N);

--- a/include/merlin/core_kernels/lookup_ptr.cuh
+++ b/include/merlin/core_kernels/lookup_ptr.cuh
@@ -412,7 +412,7 @@ __global__ void lookup_ptr_kernel(const Table<K, V, S, SS>* __restrict table,
         start_idx = (start_idx / TILE_SIZE) * TILE_SIZE;
       }
 
-      occupy_result = find_without_lock<K, V, S, TILE_SIZE>(
+      occupy_result = find_without_lock<K, V, S, SS, TILE_SIZE>(
           g, bucket, find_key, start_idx, key_pos, src_lane, bucket_max_size);
     } else {
       occupy_result = OccupyResult::ILLEGAL;

--- a/include/merlin/core_kernels/update.cuh
+++ b/include/merlin/core_kernels/update.cuh
@@ -23,13 +23,14 @@ namespace merlin {
 
 // Use 1 thread to deal with a KV-pair, including copying value.
 template <typename K = uint64_t, typename V = byte4, typename S = uint64_t,
-          typename VecV = byte16, uint32_t BLOCK_SIZE = 128, int Strategy = -1>
+          class SS = AtomicScore<S>, typename VecV = byte16,
+          uint32_t BLOCK_SIZE = 128, int Strategy = -1>
 __global__ void tlp_update_kernel_with_io(
-    Bucket<K, V, S>* __restrict__ buckets, const uint64_t buckets_num,
+    Bucket<K, V, S, SS>* __restrict__ buckets, const uint64_t buckets_num,
     uint32_t bucket_capacity, const uint32_t dim, const K* __restrict__ keys,
     const VecV* __restrict__ values, const S* __restrict__ scores, uint64_t n,
     const S global_epoch) {
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using CopyValue = CopyValueMultipleGroup<VecV, 1>;
   using ScoreFunctor = ScoreFunctor<K, V, S, Strategy>;
 
@@ -132,10 +133,11 @@ __global__ void tlp_update_kernel_with_io(
   }
 }
 template <typename K = uint64_t, typename V = byte4, typename S = uint64_t,
-          typename VecV = byte16, uint32_t BLOCK_SIZE = 128,
-          uint32_t GROUP_SIZE = 16, int Strategy = -1>
+          class SS = AtomicScore<S>, typename VecV = byte16,
+          uint32_t BLOCK_SIZE = 128, uint32_t GROUP_SIZE = 16,
+          int Strategy = -1>
 __global__ void pipeline_update_kernel_with_io(
-    Bucket<K, V, S>* __restrict__ buckets, const uint64_t buckets_num,
+    Bucket<K, V, S, SS>* __restrict__ buckets, const uint64_t buckets_num,
     const uint32_t dim, const K* __restrict__ keys,
     const VecV* __restrict__ values, const S* __restrict__ scores, uint64_t n,
     const S global_epoch) {
@@ -147,7 +149,7 @@ __global__ void pipeline_update_kernel_with_io(
   constexpr uint32_t Load_LEN = sizeof(VecD_Load) / sizeof(D);
   constexpr int RESERVE = 8;
 
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using CopyValue = CopyValueMultipleGroup<VecV, GROUP_SIZE>;
   using CopyScore = CopyScoreByPassCache<S, K, BUCKET_SIZE>;
   using ScoreFunctor = ScoreFunctor<K, V, S, Strategy>;
@@ -187,7 +189,7 @@ __global__ void pipeline_update_kernel_with_io(
     sm_target_digests[idx_block] = digests_from_hashed<K>(hashed_key);
     uint64_t global_idx = hashed_key % (buckets_num * BUCKET_SIZE);
     uint64_t bkt_idx = global_idx / BUCKET_SIZE;
-    Bucket<K, V, S>* bucket = buckets + bkt_idx;
+    Bucket<K, V, S, SS>* bucket = buckets + bkt_idx;
     __pipeline_memcpy_async(sm_keys_ptr + idx_block, bucket->keys_addr(),
                             sizeof(K*));
     __pipeline_commit();
@@ -488,9 +490,10 @@ __global__ void pipeline_update_kernel_with_io(
   }
 }  // End function
 
-template <typename K = uint64_t, typename V = float, typename S = uint64_t>
+template <typename K = uint64_t, typename V = float, typename S = uint64_t,
+          class SS = AtomicScore<S>>
 struct Params_Update {
-  Params_Update(float load_factor_, Bucket<K, V, S>* __restrict__ buckets_,
+  Params_Update(float load_factor_, Bucket<K, V, S, SS>* __restrict__ buckets_,
                 size_t buckets_num_, uint32_t bucket_capacity_, uint32_t dim_,
                 const K* __restrict__ keys_, const V* __restrict__ values_,
                 const S* __restrict__ scores_, size_t n_, const S global_epoch_)
@@ -505,7 +508,7 @@ struct Params_Update {
         n(n_),
         global_epoch(global_epoch_) {}
   float load_factor;
-  Bucket<K, V, S>* __restrict__ buckets;
+  Bucket<K, V, S, SS>* __restrict__ buckets;
   size_t buckets_num;
   uint32_t bucket_capacity;
   uint32_t dim;
@@ -516,13 +519,14 @@ struct Params_Update {
   const S global_epoch;
 };
 
-template <typename K, typename V, typename S, typename VecV, int Strategy>
+template <typename K, typename V, typename S, class SS, typename VecV,
+          int Strategy>
 struct Launch_TLP_Update {
-  using Params = Params_Update<K, V, S>;
+  using Params = Params_Update<K, V, S, SS>;
   inline static void launch_kernel(Params& params, cudaStream_t& stream) {
     constexpr int BLOCK_SIZE = 128;
     params.dim = params.dim * sizeof(V) / sizeof(VecV);
-    tlp_update_kernel_with_io<K, V, S, VecV, BLOCK_SIZE, Strategy>
+    tlp_update_kernel_with_io<K, V, S, SS, VecV, BLOCK_SIZE, Strategy>
         <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
             params.buckets, params.buckets_num, params.bucket_capacity,
             params.dim, params.keys,
@@ -531,9 +535,10 @@ struct Launch_TLP_Update {
   }
 };
 
-template <typename K, typename V, typename S, typename VecV, int Strategy>
+template <typename K, typename V, typename S, class SS, typename VecV,
+          int Strategy>
 struct Launch_Pipeline_Update {
-  using Params = Params_Update<K, V, S>;
+  using Params = Params_Update<K, V, S, SS>;
   inline static void launch_kernel(Params& params, cudaStream_t& stream) {
     constexpr int BLOCK_SIZE = 128;
     constexpr uint32_t GROUP_SIZE = 16;
@@ -543,7 +548,7 @@ struct Launch_Pipeline_Update {
     uint32_t shared_mem = GROUP_NUM * 2 * params.dim * sizeof(VecV);
     shared_mem =
         (shared_mem + sizeof(byte16) - 1) / sizeof(byte16) * sizeof(byte16);
-    pipeline_update_kernel_with_io<K, V, S, VecV, BLOCK_SIZE, GROUP_SIZE,
+    pipeline_update_kernel_with_io<K, V, S, SS, VecV, BLOCK_SIZE, GROUP_SIZE,
                                    Strategy>
         <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, shared_mem,
            stream>>>(params.buckets, params.buckets_num, params.dim,
@@ -574,10 +579,11 @@ struct ValueConfig_Update<Sm70> {
   static constexpr uint32_t size_pipeline = 64 * sizeof(byte4);
 };
 
-template <typename K, typename V, typename S, int Strategy, typename ArchTag>
+template <typename K, typename V, typename S, class SS, int Strategy,
+          typename ArchTag>
 struct KernelSelector_Update {
   using ValueConfig = ValueConfig_Update<ArchTag>;
-  using Params = Params_Update<K, V, S>;
+  using Params = Params_Update<K, V, S, SS>;
 
   static bool callable(bool unique_key, uint32_t bucket_size, uint32_t dim) {
     constexpr uint32_t MinBucketCap = sizeof(VecD_Load) / sizeof(D);
@@ -597,23 +603,23 @@ struct KernelSelector_Update {
     auto launch_TLP = [&]() {
       if (total_value_size % sizeof(byte16) == 0) {
         using VecV = byte16;
-        Launch_TLP_Update<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_TLP_Update<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                   stream);
       } else if (total_value_size % sizeof(byte8) == 0) {
         using VecV = byte8;
-        Launch_TLP_Update<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_TLP_Update<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                   stream);
       } else if (total_value_size % sizeof(byte4) == 0) {
         using VecV = byte4;
-        Launch_TLP_Update<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_TLP_Update<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                   stream);
       } else if (total_value_size % sizeof(byte2) == 0) {
         using VecV = byte2;
-        Launch_TLP_Update<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_TLP_Update<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                   stream);
       } else {
         using VecV = byte;
-        Launch_TLP_Update<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_TLP_Update<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                   stream);
       }
     };
@@ -621,23 +627,23 @@ struct KernelSelector_Update {
     auto launch_Pipeline = [&]() {
       if (total_value_size % sizeof(byte16) == 0) {
         using VecV = byte16;
-        Launch_Pipeline_Update<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_Pipeline_Update<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                        stream);
       } else if (total_value_size % sizeof(byte8) == 0) {
         using VecV = byte8;
-        Launch_Pipeline_Update<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_Pipeline_Update<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                        stream);
       } else if (total_value_size % sizeof(byte4) == 0) {
         using VecV = byte4;
-        Launch_Pipeline_Update<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_Pipeline_Update<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                        stream);
       } else if (total_value_size % sizeof(byte2) == 0) {
         using VecV = byte2;
-        Launch_Pipeline_Update<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_Pipeline_Update<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                        stream);
       } else {
         using VecV = byte;
-        Launch_Pipeline_Update<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_Pipeline_Update<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                        stream);
       }
     };
@@ -662,9 +668,10 @@ struct KernelSelector_Update {
  * update with IO operation. This kernel is
  * usually used for the pure HBM mode for better performance.
  */
-template <class K, class V, class S, int Strategy, uint32_t TILE_SIZE = 4>
+template <class K, class V, class S, class SS, int Strategy,
+          uint32_t TILE_SIZE = 4>
 __global__ void update_kernel_with_io(
-    const Table<K, V, S>* __restrict table, Bucket<K, V, S>* buckets,
+    const Table<K, V, S, SS>* __restrict table, Bucket<K, V, S, SS>* buckets,
     const size_t bucket_max_size, const size_t buckets_num, const size_t dim,
     const K* __restrict keys, const V* __restrict values,
     const S* __restrict scores, const S global_epoch, const size_t N) {
@@ -688,7 +695,7 @@ __global__ void update_kernel_with_io(
     size_t start_idx = 0;
     int src_lane = -1;
 
-    Bucket<K, V, S>* bucket = get_key_position<K>(
+    Bucket<K, V, S, SS>* bucket = get_key_position<K>(
         buckets, update_key, bkt_idx, start_idx, buckets_num, bucket_max_size);
 
     OccupyResult occupy_result{OccupyResult::INITIAL};
@@ -720,21 +727,21 @@ __global__ void update_kernel_with_io(
   }
 }
 
-template <typename K, typename V, typename S, int Strategy>
+template <typename K, typename V, typename S, class SS, int Strategy>
 struct SelectUpdateKernelWithIO {
   static void execute_kernel(const float& load_factor, const int& block_size,
                              const size_t bucket_max_size,
                              const size_t buckets_num, const size_t dim,
                              cudaStream_t& stream, const size_t& n,
-                             const Table<K, V, S>* __restrict table,
-                             Bucket<K, V, S>* buckets, const K* __restrict keys,
+                             const Table<K, V, S, SS>* __restrict table,
+                             Bucket<K, V, S, SS>* buckets, const K* __restrict keys,
                              const V* __restrict values,
                              const S* __restrict scores, const S global_epoch) {
     if (load_factor <= 0.75) {
       const unsigned int tile_size = 4;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      update_kernel_with_io<K, V, S, Strategy, tile_size>
+      update_kernel_with_io<K, V, S, SS, Strategy, tile_size>
           <<<grid_size, block_size, 0, stream>>>(
               table, buckets, bucket_max_size, buckets_num, dim, keys, values,
               scores, global_epoch, N);
@@ -742,7 +749,7 @@ struct SelectUpdateKernelWithIO {
       const unsigned int tile_size = 32;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      update_kernel_with_io<K, V, S, Strategy, tile_size>
+      update_kernel_with_io<K, V, S, SS, Strategy, tile_size>
           <<<grid_size, block_size, 0, stream>>>(
               table, buckets, bucket_max_size, buckets_num, dim, keys, values,
               scores, global_epoch, N);
@@ -752,14 +759,15 @@ struct SelectUpdateKernelWithIO {
 };
 
 // Use 1 thread to deal with a KV-pair, including copying value.
-template <typename K, typename V, typename S, int Strategy = -1>
+template <typename K, typename V, typename S, class SS = AtomicScore<S>,
+          int Strategy = -1>
 __global__ void tlp_update_kernel_hybrid(
-    Bucket<K, V, S>* __restrict__ buckets, const uint64_t buckets_num,
+    Bucket<K, V, S, SS>* __restrict__ buckets, const uint64_t buckets_num,
     uint32_t bucket_capacity, const uint32_t dim, const K* __restrict__ keys,
     V** __restrict__ values, const S* __restrict__ scores,
     K** __restrict__ key_ptrs, int* __restrict src_offset, const S global_epoch,
     uint64_t n) {
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using ScoreFunctor = ScoreFunctor<K, V, S, Strategy>;
 
   uint32_t tx = threadIdx.x;
@@ -857,9 +865,10 @@ __global__ void tlp_update_kernel_hybrid(
   }
 }
 
-template <class K, class V, class S, int Strategy, uint32_t TILE_SIZE = 4>
-__global__ void update_kernel(const Table<K, V, S>* __restrict table,
-                              Bucket<K, V, S>* buckets,
+template <class K, class V, class S, class SS, int Strategy,
+          uint32_t TILE_SIZE = 4>
+__global__ void update_kernel(const Table<K, V, S, SS>* __restrict table,
+                              Bucket<K, V, S, SS>* buckets,
                               const size_t bucket_max_size,
                               const size_t buckets_num, const size_t dim,
                               const K* __restrict keys, V** __restrict vectors,
@@ -884,7 +893,7 @@ __global__ void update_kernel(const Table<K, V, S>* __restrict table,
     size_t start_idx = 0;
     int src_lane = -1;
 
-    Bucket<K, V, S>* bucket = get_key_position<K>(
+    Bucket<K, V, S, SS>* bucket = get_key_position<K>(
         buckets, update_key, bkt_idx, start_idx, buckets_num, bucket_max_size);
 
     OccupyResult occupy_result{OccupyResult::INITIAL};

--- a/include/merlin/core_kernels/update.cuh
+++ b/include/merlin/core_kernels/update.cuh
@@ -704,7 +704,7 @@ __global__ void update_kernel_with_io(
     if (bucket_size >= bucket_max_size) {
       start_idx = (start_idx / TILE_SIZE) * TILE_SIZE;
     }
-    occupy_result = find_and_lock_for_update<K, V, S, TILE_SIZE>(
+    occupy_result = find_and_lock_for_update<K, V, S, SS, TILE_SIZE>(
         g, bucket, update_key, start_idx, key_pos, src_lane, bucket_max_size);
 
     occupy_result = g.shfl(occupy_result, src_lane);
@@ -903,7 +903,7 @@ __global__ void update_kernel(const Table<K, V, S, SS>* __restrict table,
     if (bucket_size >= bucket_max_size) {
       start_idx = (start_idx / TILE_SIZE) * TILE_SIZE;
     }
-    occupy_result = find_and_lock_for_update<K, V, S, TILE_SIZE>(
+    occupy_result = find_and_lock_for_update<K, V, S, SS, TILE_SIZE>(
         g, bucket, update_key, start_idx, key_pos, src_lane, bucket_max_size);
 
     occupy_result = g.shfl(occupy_result, src_lane);

--- a/include/merlin/core_kernels/update_score.cuh
+++ b/include/merlin/core_kernels/update_score.cuh
@@ -23,14 +23,15 @@ namespace merlin {
 
 // Use 1 thread to deal with a KV-pair, including copying value.
 template <typename K = uint64_t, typename V = byte4, typename S = uint64_t,
-          uint32_t BLOCK_SIZE = 128, int Strategy = -1>
-__global__ void tlp_update_score_kernel(Bucket<K, V, S>* __restrict__ buckets,
+          class SS = AtomicScore<S>, uint32_t BLOCK_SIZE = 128,
+          int Strategy = -1>
+__global__ void tlp_update_score_kernel(Bucket<K, V, S, SS>* __restrict__ buckets,
                                         const uint64_t buckets_num,
                                         uint32_t bucket_capacity,
                                         const K* __restrict__ keys,
                                         const S* __restrict__ scores,
                                         uint64_t n, const S global_epoch) {
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using ScoreFunctor = ScoreFunctor<K, V, S, Strategy>;
 
   uint32_t tx = threadIdx.x;
@@ -127,10 +128,10 @@ __global__ void tlp_update_score_kernel(Bucket<K, V, S>* __restrict__ buckets,
   }
 }
 template <typename K = uint64_t, typename V = byte4, typename S = uint64_t,
-          uint32_t BLOCK_SIZE = 128, uint32_t GROUP_SIZE = 16,
-          int Strategy = -1>
+          class SS = AtomicScore<S>, uint32_t BLOCK_SIZE = 128,
+          uint32_t GROUP_SIZE = 16, int Strategy = -1>
 __global__ void pipeline_update_score_kernel(
-    Bucket<K, V, S>* __restrict__ buckets, const uint64_t buckets_num,
+    Bucket<K, V, S, SS>* __restrict__ buckets, const uint64_t buckets_num,
     const K* __restrict__ keys, const S* __restrict__ scores, uint64_t n,
     const S global_epoch) {
   constexpr uint32_t BUCKET_SIZE = 128;
@@ -141,7 +142,7 @@ __global__ void pipeline_update_score_kernel(
   constexpr uint32_t Load_LEN = sizeof(VecD_Load) / sizeof(D);
   constexpr int RESERVE = 8;
 
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using CopyScore = CopyScoreByPassCache<S, K, BUCKET_SIZE>;
   using ScoreFunctor = ScoreFunctor<K, V, S, Strategy>;
 
@@ -176,7 +177,7 @@ __global__ void pipeline_update_score_kernel(
     sm_target_digests[idx_block] = digests_from_hashed<K>(hashed_key);
     uint64_t global_idx = hashed_key % (buckets_num * BUCKET_SIZE);
     uint64_t bkt_idx = global_idx / BUCKET_SIZE;
-    Bucket<K, V, S>* bucket = buckets + bkt_idx;
+    Bucket<K, V, S, SS>* bucket = buckets + bkt_idx;
     __pipeline_memcpy_async(sm_keys_ptr + idx_block, bucket->keys_addr(),
                             sizeof(K*));
     __pipeline_commit();
@@ -450,9 +451,10 @@ __global__ void pipeline_update_score_kernel(
   }
 }  // End function
 
-template <typename K = uint64_t, typename V = float, typename S = uint64_t>
+template <typename K = uint64_t, typename V = float, typename S = uint64_t,
+          class SS = AtomicScore<S>>
 struct Params_UpdateScore {
-  Params_UpdateScore(float load_factor_, Bucket<K, V, S>* __restrict__ buckets_,
+  Params_UpdateScore(float load_factor_, Bucket<K, V, S, SS>* __restrict__ buckets_,
                      size_t buckets_num_, uint32_t bucket_capacity_,
                      const K* __restrict__ keys_, const S* __restrict__ scores_,
                      size_t n_, const S global_epoch_)
@@ -465,7 +467,7 @@ struct Params_UpdateScore {
         n(n_),
         global_epoch(global_epoch_) {}
   float load_factor;
-  Bucket<K, V, S>* __restrict__ buckets;
+  Bucket<K, V, S, SS>* __restrict__ buckets;
   size_t buckets_num;
   uint32_t bucket_capacity;
   const K* __restrict__ keys;
@@ -474,35 +476,35 @@ struct Params_UpdateScore {
   const S global_epoch;
 };
 
-template <typename K, typename V, typename S, int Strategy>
+template <typename K, typename V, typename S, class SS, int Strategy>
 struct Launch_TLP_UpdateScore {
-  using Params = Params_UpdateScore<K, V, S>;
+  using Params = Params_UpdateScore<K, V, S, SS>;
   inline static void launch_kernel(Params& params, cudaStream_t& stream) {
     constexpr int BLOCK_SIZE = 128;
-    tlp_update_score_kernel<K, V, S, BLOCK_SIZE, Strategy>
+    tlp_update_score_kernel<K, V, S, SS, BLOCK_SIZE, Strategy>
         <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
             params.buckets, params.buckets_num, params.bucket_capacity,
             params.keys, params.scores, params.n, params.global_epoch);
   }
 };
 
-template <typename K, typename V, typename S, int Strategy>
+template <typename K, typename V, typename S, class SS, int Strategy>
 struct Launch_Pipeline_UpdateScore {
-  using Params = Params_UpdateScore<K, V, S>;
+  using Params = Params_UpdateScore<K, V, S, SS>;
   inline static void launch_kernel(Params& params, cudaStream_t& stream) {
     constexpr int BLOCK_SIZE = 128;
     constexpr uint32_t GROUP_SIZE = 16;
 
-    pipeline_update_score_kernel<K, V, S, BLOCK_SIZE, GROUP_SIZE, Strategy>
+    pipeline_update_score_kernel<K, V, S, SS, BLOCK_SIZE, GROUP_SIZE, Strategy>
         <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
             params.buckets, params.buckets_num, params.keys, params.scores,
             params.n, params.global_epoch);
   }
 };
 
-template <typename K, typename V, typename S, int Strategy>
+template <typename K, typename V, typename S, class SS, int Strategy>
 struct KernelSelector_UpdateScore {
-  using Params = Params_UpdateScore<K, V, S>;
+  using Params = Params_UpdateScore<K, V, S, SS>;
 
   static bool callable(bool unique_key, uint32_t bucket_size) {
     constexpr uint32_t MinBucketCap = sizeof(VecD_Load) / sizeof(D);
@@ -512,13 +514,13 @@ struct KernelSelector_UpdateScore {
   static void select_kernel(Params& params, cudaStream_t& stream) {
     // This part is according to the test on A100.
     if (params.bucket_capacity != 128) {
-      Launch_TLP_UpdateScore<K, V, S, Strategy>::launch_kernel(params, stream);
+      Launch_TLP_UpdateScore<K, V, S, SS, Strategy>::launch_kernel(params, stream);
     } else {
       if (params.load_factor <= 0.60f) {
-        Launch_TLP_UpdateScore<K, V, S, Strategy>::launch_kernel(params,
+        Launch_TLP_UpdateScore<K, V, S, SS, Strategy>::launch_kernel(params,
                                                                  stream);
       } else {
-        Launch_Pipeline_UpdateScore<K, V, S, Strategy>::launch_kernel(params,
+        Launch_Pipeline_UpdateScore<K, V, S, SS, Strategy>::launch_kernel(params,
                                                                       stream);
       }
     }
@@ -529,9 +531,10 @@ struct KernelSelector_UpdateScore {
  * update with IO operation. This kernel is
  * usually used for the pure HBM mode for better performance.
  */
-template <class K, class V, class S, int Strategy, uint32_t TILE_SIZE = 4>
-__global__ void update_score_kernel(const Table<K, V, S>* __restrict table,
-                                    Bucket<K, V, S>* buckets,
+template <class K, class V, class S, class SS, int Strategy,
+          uint32_t TILE_SIZE = 4>
+__global__ void update_score_kernel(const Table<K, V, S, SS>* __restrict table,
+                                    Bucket<K, V, S, SS>* buckets,
                                     const size_t bucket_max_size,
                                     const size_t buckets_num,
                                     const K* __restrict keys,
@@ -555,7 +558,7 @@ __global__ void update_score_kernel(const Table<K, V, S>* __restrict table,
     size_t start_idx = 0;
     int src_lane = -1;
 
-    Bucket<K, V, S>* bucket = get_key_position<K>(
+    Bucket<K, V, S, SS>* bucket = get_key_position<K>(
         buckets, update_key, bkt_idx, start_idx, buckets_num, bucket_max_size);
 
     OccupyResult occupy_result{OccupyResult::INITIAL};
@@ -585,20 +588,20 @@ __global__ void update_score_kernel(const Table<K, V, S>* __restrict table,
   }
 }
 
-template <typename K, typename V, typename S, int Strategy>
+template <typename K, typename V, typename S, class SS, int Strategy>
 struct SelectUpdateScoreKernel {
   static void execute_kernel(const float& load_factor, const int& block_size,
                              const size_t bucket_max_size,
                              const size_t buckets_num, cudaStream_t& stream,
                              const size_t& n,
-                             const Table<K, V, S>* __restrict table,
-                             Bucket<K, V, S>* buckets, const K* __restrict keys,
+                             const Table<K, V, S, SS>* __restrict table,
+                             Bucket<K, V, S, SS>* buckets, const K* __restrict keys,
                              const S* __restrict scores, const S global_epoch) {
     if (load_factor <= 0.75) {
       const unsigned int tile_size = 4;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      update_score_kernel<K, V, S, Strategy, tile_size>
+      update_score_kernel<K, V, S, SS, Strategy, tile_size>
           <<<grid_size, block_size, 0, stream>>>(table, buckets,
                                                  bucket_max_size, buckets_num,
                                                  keys, scores, global_epoch, N);
@@ -606,7 +609,7 @@ struct SelectUpdateScoreKernel {
       const unsigned int tile_size = 32;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      update_score_kernel<K, V, S, Strategy, tile_size>
+      update_score_kernel<K, V, S, SS, Strategy, tile_size>
           <<<grid_size, block_size, 0, stream>>>(table, buckets,
                                                  bucket_max_size, buckets_num,
                                                  keys, scores, global_epoch, N);

--- a/include/merlin/core_kernels/update_score.cuh
+++ b/include/merlin/core_kernels/update_score.cuh
@@ -567,7 +567,7 @@ __global__ void update_score_kernel(const Table<K, V, S, SS>* __restrict table,
     if (bucket_size >= bucket_max_size) {
       start_idx = (start_idx / TILE_SIZE) * TILE_SIZE;
     }
-    occupy_result = find_and_lock_for_update<K, V, S, TILE_SIZE>(
+    occupy_result = find_and_lock_for_update<K, V, S, SS, TILE_SIZE>(
         g, bucket, update_key, start_idx, key_pos, src_lane, bucket_max_size);
 
     occupy_result = g.shfl(occupy_result, src_lane);

--- a/include/merlin/core_kernels/update_values.cuh
+++ b/include/merlin/core_kernels/update_values.cuh
@@ -23,12 +23,13 @@ namespace merlin {
 
 // Use 1 thread to deal with a KV-pair, including copying value.
 template <typename K = uint64_t, typename V = byte4, typename S = uint64_t,
-          typename VecV = byte16, uint32_t BLOCK_SIZE = 128>
+          typename SS = AtomicScore<S>, typename VecV = byte16,
+          uint32_t BLOCK_SIZE = 128>
 __global__ void tlp_update_values_kernel_with_io(
-    Bucket<K, V, S>* __restrict__ buckets, const uint64_t buckets_num,
+    Bucket<K, V, S, SS>* __restrict__ buckets, const uint64_t buckets_num,
     uint32_t bucket_capacity, const uint32_t dim, const K* __restrict__ keys,
     const VecV* __restrict__ values, uint64_t n) {
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using CopyValue = CopyValueMultipleGroup<VecV, 1>;
 
   uint32_t tx = threadIdx.x;
@@ -127,10 +128,10 @@ __global__ void tlp_update_values_kernel_with_io(
   }
 }
 template <typename K = uint64_t, typename V = byte4, typename S = uint64_t,
-          typename VecV = byte16, uint32_t BLOCK_SIZE = 128,
-          uint32_t GROUP_SIZE = 16>
+          typename SS = AtomicScore<S>, typename VecV = byte16,
+          uint32_t BLOCK_SIZE = 128, uint32_t GROUP_SIZE = 16>
 __global__ void pipeline_update_values_kernel_with_io(
-    Bucket<K, V, S>* __restrict__ buckets, const uint64_t buckets_num,
+    Bucket<K, V, S, SS>* __restrict__ buckets, const uint64_t buckets_num,
     const uint32_t dim, const K* __restrict__ keys,
     const VecV* __restrict__ values, uint64_t n) {
   constexpr uint32_t BUCKET_SIZE = 128;
@@ -141,7 +142,7 @@ __global__ void pipeline_update_values_kernel_with_io(
   constexpr uint32_t Load_LEN = sizeof(VecD_Load) / sizeof(D);
   constexpr int RESERVE = 8;
 
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using CopyValue = CopyValueMultipleGroup<VecV, GROUP_SIZE>;
 
   __shared__ VecD_Comp sm_target_digests[BLOCK_SIZE];
@@ -178,7 +179,7 @@ __global__ void pipeline_update_values_kernel_with_io(
     sm_target_digests[idx_block] = digests_from_hashed<K>(hashed_key);
     uint64_t global_idx = hashed_key % (buckets_num * BUCKET_SIZE);
     uint64_t bkt_idx = global_idx / BUCKET_SIZE;
-    Bucket<K, V, S>* bucket = buckets + bkt_idx;
+    Bucket<K, V, S, SS>* bucket = buckets + bkt_idx;
     __pipeline_memcpy_async(sm_keys_ptr + idx_block, bucket->keys_addr(),
                             sizeof(K*));
     __pipeline_commit();
@@ -459,10 +460,11 @@ __global__ void pipeline_update_values_kernel_with_io(
   }
 }  // End function
 
-template <typename K = uint64_t, typename V = float, typename S = uint64_t>
+template <typename K = uint64_t, typename V = float, typename S = uint64_t,
+          typename SS = AtomicScore<S>>
 struct Params_UpdateValues {
   Params_UpdateValues(float load_factor_,
-                      Bucket<K, V, S>* __restrict__ buckets_,
+                      Bucket<K, V, S, SS>* __restrict__ buckets_,
                       size_t buckets_num_, uint32_t bucket_capacity_,
                       uint32_t dim_, const K* __restrict__ keys_,
                       const V* __restrict__ values_, size_t n_)
@@ -475,7 +477,7 @@ struct Params_UpdateValues {
         values(values_),
         n(n_) {}
   float load_factor;
-  Bucket<K, V, S>* __restrict__ buckets;
+  Bucket<K, V, S, SS>* __restrict__ buckets;
   size_t buckets_num;
   uint32_t bucket_capacity;
   uint32_t dim;
@@ -484,13 +486,13 @@ struct Params_UpdateValues {
   uint64_t n;
 };
 
-template <typename K, typename V, typename S, typename VecV>
+template <typename K, typename V, typename S, typename SS, typename VecV>
 struct Launch_TLP_UpdateValues {
-  using Params = Params_UpdateValues<K, V, S>;
+  using Params = Params_UpdateValues<K, V, S, SS>;
   inline static void launch_kernel(Params& params, cudaStream_t& stream) {
     constexpr int BLOCK_SIZE = 128;
     params.dim = params.dim * sizeof(V) / sizeof(VecV);
-    tlp_update_values_kernel_with_io<K, V, S, VecV, BLOCK_SIZE>
+    tlp_update_values_kernel_with_io<K, V, S, SS, VecV, BLOCK_SIZE>
         <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
             params.buckets, params.buckets_num, params.bucket_capacity,
             params.dim, params.keys,
@@ -498,9 +500,9 @@ struct Launch_TLP_UpdateValues {
   }
 };
 
-template <typename K, typename V, typename S, typename VecV>
+template <typename K, typename V, typename S, typename SS, typename VecV>
 struct Launch_Pipeline_UpdateValues {
-  using Params = Params_UpdateValues<K, V, S>;
+  using Params = Params_UpdateValues<K, V, S, SS>;
   inline static void launch_kernel(Params& params, cudaStream_t& stream) {
     constexpr int BLOCK_SIZE = 128;
     constexpr uint32_t GROUP_SIZE = 16;
@@ -510,7 +512,7 @@ struct Launch_Pipeline_UpdateValues {
     uint32_t shared_mem = GROUP_NUM * 2 * params.dim * sizeof(VecV);
     shared_mem =
         (shared_mem + sizeof(byte16) - 1) / sizeof(byte16) * sizeof(byte16);
-    pipeline_update_values_kernel_with_io<K, V, S, VecV, BLOCK_SIZE, GROUP_SIZE>
+    pipeline_update_values_kernel_with_io<K, V, S, SS, VecV, BLOCK_SIZE, GROUP_SIZE>
         <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, shared_mem,
            stream>>>(params.buckets, params.buckets_num, params.dim,
                      params.keys, reinterpret_cast<const VecV*>(params.values),
@@ -540,10 +542,10 @@ struct ValueConfig_UpdateValues<Sm70> {
   static constexpr uint32_t size_pipeline = 64 * sizeof(byte4);
 };
 
-template <typename K, typename V, typename S, typename ArchTag>
+template <typename K, typename V, typename S, typename SS, typename ArchTag>
 struct KernelSelector_UpdateValues {
   using ValueConfig = ValueConfig_UpdateValues<ArchTag>;
-  using Params = Params_UpdateValues<K, V, S>;
+  using Params = Params_UpdateValues<K, V, S, SS>;
 
   static bool callable(bool unique_key, uint32_t bucket_size, uint32_t dim) {
     constexpr uint32_t MinBucketCap = sizeof(VecD_Load) / sizeof(D);
@@ -563,42 +565,42 @@ struct KernelSelector_UpdateValues {
     auto launch_TLP = [&]() {
       if (total_value_size % sizeof(byte16) == 0) {
         using VecV = byte16;
-        Launch_TLP_UpdateValues<K, V, S, VecV>::launch_kernel(params, stream);
+        Launch_TLP_UpdateValues<K, V, S, SS, VecV>::launch_kernel(params, stream);
       } else if (total_value_size % sizeof(byte8) == 0) {
         using VecV = byte8;
-        Launch_TLP_UpdateValues<K, V, S, VecV>::launch_kernel(params, stream);
+        Launch_TLP_UpdateValues<K, V, S, SS, VecV>::launch_kernel(params, stream);
       } else if (total_value_size % sizeof(byte4) == 0) {
         using VecV = byte4;
-        Launch_TLP_UpdateValues<K, V, S, VecV>::launch_kernel(params, stream);
+        Launch_TLP_UpdateValues<K, V, S, SS, VecV>::launch_kernel(params, stream);
       } else if (total_value_size % sizeof(byte2) == 0) {
         using VecV = byte2;
-        Launch_TLP_UpdateValues<K, V, S, VecV>::launch_kernel(params, stream);
+        Launch_TLP_UpdateValues<K, V, S, SS, VecV>::launch_kernel(params, stream);
       } else {
         using VecV = byte;
-        Launch_TLP_UpdateValues<K, V, S, VecV>::launch_kernel(params, stream);
+        Launch_TLP_UpdateValues<K, V, S, SS, VecV>::launch_kernel(params, stream);
       }
     };
 
     auto launch_Pipeline = [&]() {
       if (total_value_size % sizeof(byte16) == 0) {
         using VecV = byte16;
-        Launch_Pipeline_UpdateValues<K, V, S, VecV>::launch_kernel(params,
+        Launch_Pipeline_UpdateValues<K, V, S, SS, VecV>::launch_kernel(params,
                                                                    stream);
       } else if (total_value_size % sizeof(byte8) == 0) {
         using VecV = byte8;
-        Launch_Pipeline_UpdateValues<K, V, S, VecV>::launch_kernel(params,
+        Launch_Pipeline_UpdateValues<K, V, S, SS, VecV>::launch_kernel(params,
                                                                    stream);
       } else if (total_value_size % sizeof(byte4) == 0) {
         using VecV = byte4;
-        Launch_Pipeline_UpdateValues<K, V, S, VecV>::launch_kernel(params,
+        Launch_Pipeline_UpdateValues<K, V, S, SS, VecV>::launch_kernel(params,
                                                                    stream);
       } else if (total_value_size % sizeof(byte2) == 0) {
         using VecV = byte2;
-        Launch_Pipeline_UpdateValues<K, V, S, VecV>::launch_kernel(params,
+        Launch_Pipeline_UpdateValues<K, V, S, SS, VecV>::launch_kernel(params,
                                                                    stream);
       } else {
         using VecV = byte;
-        Launch_Pipeline_UpdateValues<K, V, S, VecV>::launch_kernel(params,
+        Launch_Pipeline_UpdateValues<K, V, S, SS, VecV>::launch_kernel(params,
                                                                    stream);
       }
     };
@@ -623,9 +625,10 @@ struct KernelSelector_UpdateValues {
  * update with IO operation. This kernel is
  * usually used for the pure HBM mode for better performance.
  */
-template <class K, class V, class S, uint32_t TILE_SIZE = 4>
+template <class K, class V, class S, class SS = AtomicScore<S>,
+          uint32_t TILE_SIZE = 4>
 __global__ void update_values_kernel_with_io(
-    const Table<K, V, S>* __restrict table, Bucket<K, V, S>* buckets,
+    const Table<K, V, S, SS>* __restrict table, Bucket<K, V, S, SS>* buckets,
     const size_t bucket_max_size, const size_t buckets_num, const size_t dim,
     const K* __restrict keys, const V* __restrict values, const size_t N) {
   auto g = cg::tiled_partition<TILE_SIZE>(cg::this_thread_block());
@@ -646,7 +649,7 @@ __global__ void update_values_kernel_with_io(
     size_t start_idx = 0;
     int src_lane = -1;
 
-    Bucket<K, V, S>* bucket = get_key_position<K>(
+    Bucket<K, V, S, SS>* bucket = get_key_position<K>(
         buckets, update_key, bkt_idx, start_idx, buckets_num, bucket_max_size);
 
     OccupyResult occupy_result{OccupyResult::INITIAL};
@@ -674,20 +677,20 @@ __global__ void update_values_kernel_with_io(
   }
 }
 
-template <typename K, typename V, typename S>
+template <typename K, typename V, typename S, typename SS = AtomicScore<S>>
 struct SelectUpdateValuesKernelWithIO {
   static void execute_kernel(const float& load_factor, const int& block_size,
                              const size_t bucket_max_size,
                              const size_t buckets_num, const size_t dim,
                              cudaStream_t& stream, const size_t& n,
-                             const Table<K, V, S>* __restrict table,
-                             Bucket<K, V, S>* buckets, const K* __restrict keys,
+                             const Table<K, V, S, SS>* __restrict table,
+                             Bucket<K, V, S, SS>* buckets, const K* __restrict keys,
                              const V* __restrict values) {
     if (load_factor <= 0.75) {
       const unsigned int tile_size = 4;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      update_values_kernel_with_io<K, V, S, tile_size>
+      update_values_kernel_with_io<K, V, S, SS, tile_size>
           <<<grid_size, block_size, 0, stream>>>(table, buckets,
                                                  bucket_max_size, buckets_num,
                                                  dim, keys, values, N);
@@ -695,7 +698,7 @@ struct SelectUpdateValuesKernelWithIO {
       const unsigned int tile_size = 32;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      update_values_kernel_with_io<K, V, S, tile_size>
+      update_values_kernel_with_io<K, V, S, SS, tile_size>
           <<<grid_size, block_size, 0, stream>>>(table, buckets,
                                                  bucket_max_size, buckets_num,
                                                  dim, keys, values, N);
@@ -705,13 +708,13 @@ struct SelectUpdateValuesKernelWithIO {
 };
 
 // Use 1 thread to deal with a KV-pair, including copying value.
-template <typename K, typename V, typename S>
+template <typename K, typename V, typename S, typename SS = AtomicScore<S>>
 __global__ void tlp_update_values_kernel_hybrid(
-    Bucket<K, V, S>* __restrict__ buckets, const uint64_t buckets_num,
+    Bucket<K, V, S, SS>* __restrict__ buckets, const uint64_t buckets_num,
     uint32_t bucket_capacity, const uint32_t dim, const K* __restrict__ keys,
     V** __restrict__ values, K** __restrict__ key_ptrs,
     int* __restrict src_offset, uint64_t n) {
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
 
   uint32_t tx = threadIdx.x;
   uint32_t kv_idx = blockIdx.x * blockDim.x + tx;
@@ -805,9 +808,10 @@ __global__ void tlp_update_values_kernel_hybrid(
   }
 }
 
-template <class K, class V, class S, uint32_t TILE_SIZE = 4>
-__global__ void update_values_kernel(const Table<K, V, S>* __restrict table,
-                                     Bucket<K, V, S>* buckets,
+template <class K, class V, class S, class SS = AtomicScore<S>,
+          uint32_t TILE_SIZE = 4>
+__global__ void update_values_kernel(const Table<K, V, S, SS>* __restrict table,
+                                     Bucket<K, V, S, SS>* buckets,
                                      const size_t bucket_max_size,
                                      const size_t buckets_num, const size_t dim,
                                      const K* __restrict keys,
@@ -829,7 +833,7 @@ __global__ void update_values_kernel(const Table<K, V, S>* __restrict table,
     size_t start_idx = 0;
     int src_lane = -1;
 
-    Bucket<K, V, S>* bucket = get_key_position<K>(
+    Bucket<K, V, S, SS>* bucket = get_key_position<K>(
         buckets, update_key, bkt_idx, start_idx, buckets_num, bucket_max_size);
 
     OccupyResult occupy_result{OccupyResult::INITIAL};

--- a/include/merlin/core_kernels/update_values.cuh
+++ b/include/merlin/core_kernels/update_values.cuh
@@ -658,7 +658,7 @@ __global__ void update_values_kernel_with_io(
     if (bucket_size >= bucket_max_size) {
       start_idx = (start_idx / TILE_SIZE) * TILE_SIZE;
     }
-    occupy_result = find_and_lock_for_update<K, V, S, TILE_SIZE>(
+    occupy_result = find_and_lock_for_update<K, V, S, SS, TILE_SIZE>(
         g, bucket, update_key, start_idx, key_pos, src_lane, bucket_max_size);
 
     occupy_result = g.shfl(occupy_result, src_lane);
@@ -843,7 +843,7 @@ __global__ void update_values_kernel(const Table<K, V, S, SS>* __restrict table,
     if (bucket_size >= bucket_max_size) {
       start_idx = (start_idx / TILE_SIZE) * TILE_SIZE;
     }
-    occupy_result = find_and_lock_for_update<K, V, S, TILE_SIZE>(
+    occupy_result = find_and_lock_for_update<K, V, S, SS, TILE_SIZE>(
         g, bucket, update_key, start_idx, key_pos, src_lane, bucket_max_size);
 
     occupy_result = g.shfl(occupy_result, src_lane);

--- a/include/merlin/core_kernels/upsert.cuh
+++ b/include/merlin/core_kernels/upsert.cuh
@@ -23,13 +23,14 @@ namespace merlin {
 
 // Use 1 thread to deal with a KV-pair, including copying value.
 template <typename K = uint64_t, typename V = byte4, typename S = uint64_t,
-          typename VecV = byte16, uint32_t BLOCK_SIZE = 128, int Strategy = -1>
+          class SS = AtomicScore<S>, typename VecV = byte16,
+          uint32_t BLOCK_SIZE = 128, int Strategy = -1>
 __global__ void tlp_v1_upsert_kernel_with_io(
-    Bucket<K, V, S>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
+    Bucket<K, V, S, SS>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
     const uint64_t buckets_num, uint32_t bucket_capacity, const uint32_t dim,
     const K* __restrict__ keys, const VecV* __restrict__ values,
     const S* __restrict__ scores, uint64_t n, const S global_epoch) {
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using CopyValue = CopyValueMultipleGroup<VecV, 1>;
   using ScoreFunctor = ScoreFunctor<K, V, S, Strategy>;
 
@@ -199,10 +200,7 @@ __global__ void tlp_v1_upsert_kernel_with_io(
       if (result) {
         S* min_score_ptr =
             BUCKET::scores(bucket_keys_ptr, bucket_capacity, min_pos);
-        auto verify_score_ptr =
-            reinterpret_cast<AtomicScore<S>*>(min_score_ptr);
-        auto verify_score =
-            verify_score_ptr->load(cuda::std::memory_order_relaxed);
+        auto verify_score = *min_score_ptr;
         if (verify_score <= min_score) {
           key_pos = min_pos;
           ScoreFunctor::update_with_digest(bucket_keys_ptr, key_pos, scores,
@@ -235,14 +233,15 @@ __global__ void tlp_v1_upsert_kernel_with_io(
 
 // Use 1 thread to deal with a KV-pair, including copying value.
 template <typename K = uint64_t, typename V = byte4, typename S = uint64_t,
-          typename VecV = byte16, uint32_t BLOCK_SIZE = 128,
-          uint32_t GROUP_SIZE = 16, int Strategy = -1>
+          class SS = AtomicScore<S>, typename VecV = byte16,
+          uint32_t BLOCK_SIZE = 128, uint32_t GROUP_SIZE = 16,
+          int Strategy = -1>
 __global__ void tlp_v2_upsert_kernel_with_io(
-    Bucket<K, V, S>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
+    Bucket<K, V, S, SS>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
     const uint64_t buckets_num, uint32_t bucket_capacity, const uint32_t dim,
     const K* __restrict__ keys, const VecV* __restrict__ values,
     const S* __restrict__ scores, uint64_t n, const S global_epoch) {
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using CopyValue = CopyValueMultipleGroup<VecV, GROUP_SIZE>;
   using ScoreFunctor = ScoreFunctor<K, V, S, Strategy>;
 
@@ -419,10 +418,7 @@ __global__ void tlp_v2_upsert_kernel_with_io(
       if (result) {
         S* min_score_ptr =
             BUCKET::scores(bucket_keys_ptr, bucket_capacity, min_pos);
-        auto verify_score_ptr =
-            reinterpret_cast<AtomicScore<S>*>(min_score_ptr);
-        auto verify_score =
-            verify_score_ptr->load(cuda::std::memory_order_relaxed);
+        auto verify_score = *min_score_ptr;
         if (verify_score <= min_score) {
           key_pos = min_pos;
           ScoreFunctor::update_with_digest(bucket_keys_ptr, key_pos, scores,
@@ -560,9 +556,10 @@ struct SharedMemoryManager_Pipeline_Upsert {
 };
 
 template <typename K = uint64_t, typename V = byte4, typename S = uint64_t,
-          typename VecV = byte16, uint32_t BLOCK_SIZE = 128, int Strategy = -1>
+          class SS = AtomicScore<S>, typename VecV = byte16,
+          uint32_t BLOCK_SIZE = 128, int Strategy = -1>
 __global__ void pipeline_upsert_kernel_with_io(
-    Bucket<K, V, S>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
+    Bucket<K, V, S, SS>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
     const uint64_t buckets_num, const uint32_t dim, const K* __restrict__ keys,
     const VecV* __restrict__ values, const S* __restrict__ scores, uint64_t n,
     const S global_epoch) {
@@ -573,7 +570,7 @@ __global__ void pipeline_upsert_kernel_with_io(
   constexpr uint32_t Load_LEN = sizeof(VecD_Load) / sizeof(D);
   constexpr uint32_t Load_LEN_S = sizeof(byte16) / sizeof(S);
 
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using CopyValue = CopyValueMultipleGroup<VecV, GROUP_SIZE>;
   using SMM = SharedMemoryManager_Pipeline_Upsert<K, V, S, VecV, BLOCK_SIZE,
                                                   GROUP_SIZE, BUCKET_SIZE>;
@@ -803,10 +800,7 @@ __global__ void pipeline_upsert_kernel_with_io(
               if (result) {
                 S* score_ptr = BUCKET::scores(bucket_keys_ptr, BUCKET_SIZE,
                                               min_pos_global);
-                auto verify_score_ptr =
-                    reinterpret_cast<AtomicScore<S>*>(score_ptr);
-                auto verify_score =
-                    verify_score_ptr->load(cuda::std::memory_order_relaxed);
+                auto verify_score = *score_ptr;
                 if (verify_score <= min_score_global) {
                   if (expected_key == static_cast<K>(RECLAIM_KEY)) {
                     occupy_result = OccupyResult::OCCUPIED_RECLAIMED;
@@ -912,10 +906,7 @@ __global__ void pipeline_upsert_kernel_with_io(
           if (result) {
             S* score_ptr =
                 BUCKET::scores(bucket_keys_ptr, BUCKET_SIZE, min_pos_global);
-            auto verify_score_ptr =
-                reinterpret_cast<AtomicScore<S>*>(score_ptr);
-            auto verify_score =
-                verify_score_ptr->load(cuda::std::memory_order_relaxed);
+            auto verify_score = *score_ptr;
             if (verify_score <= min_score_global) {
               if (expected_key == static_cast<K>(RECLAIM_KEY)) {
                 atomicAdd(bucket_size_ptr, 1);
@@ -985,9 +976,10 @@ __global__ void pipeline_upsert_kernel_with_io(
   }
 }
 
-template <typename K = uint64_t, typename V = float, typename S = uint64_t>
+template <typename K = uint64_t, typename V = float, typename S = uint64_t,
+          class SS = AtomicScore<S>>
 struct Params_Upsert {
-  Params_Upsert(float load_factor_, Bucket<K, V, S>* __restrict__ buckets_,
+  Params_Upsert(float load_factor_, Bucket<K, V, S, SS>* __restrict__ buckets_,
                 int* buckets_size_, size_t buckets_num_,
                 uint32_t bucket_capacity_, uint32_t dim_,
                 const K* __restrict__ keys_, const V* __restrict__ values_,
@@ -1004,7 +996,7 @@ struct Params_Upsert {
         n(n_),
         global_epoch(global_epoch_) {}
   float load_factor;
-  Bucket<K, V, S>* __restrict__ buckets;
+  Bucket<K, V, S, SS>* __restrict__ buckets;
   int* buckets_size;
   size_t buckets_num;
   uint32_t bucket_capacity;
@@ -1016,13 +1008,14 @@ struct Params_Upsert {
   const S global_epoch;
 };
 
-template <typename K, typename V, typename S, typename VecV, int Strategy>
+template <typename K, typename V, typename S, class SS, typename VecV,
+          int Strategy>
 struct Launch_TLPv1_Upsert {
-  using Params = Params_Upsert<K, V, S>;
+  using Params = Params_Upsert<K, V, S, SS>;
   inline static void launch_kernel(Params& params, cudaStream_t& stream) {
     constexpr int BLOCK_SIZE = 128;
     params.dim = params.dim * sizeof(V) / sizeof(VecV);
-    tlp_v1_upsert_kernel_with_io<K, V, S, VecV, BLOCK_SIZE, Strategy>
+    tlp_v1_upsert_kernel_with_io<K, V, S, SS, VecV, BLOCK_SIZE, Strategy>
         <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
             params.buckets, params.buckets_size, params.buckets_num,
             params.bucket_capacity, params.dim, params.keys,
@@ -1031,9 +1024,10 @@ struct Launch_TLPv1_Upsert {
   }
 };
 
-template <typename K, typename V, typename S, typename VecV, int Strategy>
+template <typename K, typename V, typename S, class SS, typename VecV,
+          int Strategy>
 struct Launch_TLPv2_Upsert {
-  using Params = Params_Upsert<K, V, S>;
+  using Params = Params_Upsert<K, V, S, SS>;
   inline static void launch_kernel(Params& params, cudaStream_t& stream) {
     constexpr int BLOCK_SIZE = 128;
     const uint32_t value_size = params.dim * sizeof(V);
@@ -1041,7 +1035,7 @@ struct Launch_TLPv2_Upsert {
 
     if (value_size <= 256) {
       constexpr int GROUP_SIZE = 8;
-      tlp_v2_upsert_kernel_with_io<K, V, S, VecV, BLOCK_SIZE, GROUP_SIZE,
+      tlp_v2_upsert_kernel_with_io<K, V, S, SS, VecV, BLOCK_SIZE, GROUP_SIZE,
                                    Strategy>
           <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
               params.buckets, params.buckets_size, params.buckets_num,
@@ -1050,7 +1044,7 @@ struct Launch_TLPv2_Upsert {
               params.n, params.global_epoch);
     } else {
       constexpr int GROUP_SIZE = 16;
-      tlp_v2_upsert_kernel_with_io<K, V, S, VecV, BLOCK_SIZE, GROUP_SIZE,
+      tlp_v2_upsert_kernel_with_io<K, V, S, SS, VecV, BLOCK_SIZE, GROUP_SIZE,
                                    Strategy>
           <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
               params.buckets, params.buckets_size, params.buckets_num,
@@ -1061,9 +1055,10 @@ struct Launch_TLPv2_Upsert {
   }
 };
 
-template <typename K, typename V, typename S, typename VecV, int Strategy>
+template <typename K, typename V, typename S, class SS, typename VecV,
+          int Strategy>
 struct Launch_Pipeline_Upsert {
-  using Params = Params_Upsert<K, V, S>;
+  using Params = Params_Upsert<K, V, S, SS>;
   inline static void launch_kernel(Params& params, cudaStream_t& stream) {
     constexpr int BLOCK_SIZE = 128;
     constexpr uint32_t GROUP_SIZE = 32;
@@ -1075,7 +1070,7 @@ struct Launch_Pipeline_Upsert {
     uint32_t shared_mem = SMM::total_size(params.dim);
     shared_mem =
         (shared_mem + sizeof(byte16) - 1) / sizeof(byte16) * sizeof(byte16);
-    pipeline_upsert_kernel_with_io<K, V, S, VecV, BLOCK_SIZE, Strategy>
+    pipeline_upsert_kernel_with_io<K, V, S, SS, VecV, BLOCK_SIZE, Strategy>
         <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, shared_mem,
            stream>>>(params.buckets, params.buckets_size, params.buckets_num,
                      params.dim, params.keys,
@@ -1101,10 +1096,11 @@ struct ValueConfig_Upsert<Sm70> {
   static constexpr uint32_t size_tlp_v2 = 128 * sizeof(byte4);
 };
 
-template <typename K, typename V, typename S, int Strategy, typename ArchTag>
+template <typename K, typename V, typename S, class SS, int Strategy,
+          typename ArchTag>
 struct KernelSelector_Upsert {
   using ValueConfig = ValueConfig_Upsert<ArchTag>;
-  using Params = Params_Upsert<K, V, S>;
+  using Params = Params_Upsert<K, V, S, SS>;
 
   static bool callable(bool unique_key, uint32_t bucket_size, uint32_t dim) {
     constexpr uint32_t MinBucketCap = sizeof(VecD_Load) / sizeof(D);
@@ -1125,23 +1121,23 @@ struct KernelSelector_Upsert {
     auto launch_TLPv1 = [&]() {
       if (total_value_size % sizeof(byte16) == 0) {
         using VecV = byte16;
-        Launch_TLPv1_Upsert<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_TLPv1_Upsert<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                     stream);
       } else if (total_value_size % sizeof(byte8) == 0) {
         using VecV = byte8;
-        Launch_TLPv1_Upsert<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_TLPv1_Upsert<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                     stream);
       } else if (total_value_size % sizeof(byte4) == 0) {
         using VecV = byte4;
-        Launch_TLPv1_Upsert<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_TLPv1_Upsert<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                     stream);
       } else if (total_value_size % sizeof(byte2) == 0) {
         using VecV = byte2;
-        Launch_TLPv1_Upsert<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_TLPv1_Upsert<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                     stream);
       } else {
         using VecV = byte;
-        Launch_TLPv1_Upsert<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_TLPv1_Upsert<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                     stream);
       }
     };
@@ -1150,23 +1146,23 @@ struct KernelSelector_Upsert {
     auto launch_TLPv2 = [&]() {
       if (total_value_size % sizeof(byte16) == 0) {
         using VecV = byte16;
-        Launch_TLPv2_Upsert<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_TLPv2_Upsert<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                     stream);
       } else if (total_value_size % sizeof(byte8) == 0) {
         using VecV = byte8;
-        Launch_TLPv2_Upsert<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_TLPv2_Upsert<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                     stream);
       } else if (total_value_size % sizeof(byte4) == 0) {
         using VecV = byte4;
-        Launch_TLPv2_Upsert<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_TLPv2_Upsert<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                     stream);
       } else if (total_value_size % sizeof(byte2) == 0) {
         using VecV = byte2;
-        Launch_TLPv2_Upsert<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_TLPv2_Upsert<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                     stream);
       } else {
         using VecV = byte;
-        Launch_TLPv2_Upsert<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_TLPv2_Upsert<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                     stream);
       }
     };
@@ -1175,23 +1171,23 @@ struct KernelSelector_Upsert {
     auto launch_Pipeline = [&]() {
       if (total_value_size % sizeof(byte16) == 0) {
         using VecV = byte16;
-        Launch_Pipeline_Upsert<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_Pipeline_Upsert<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                        stream);
       } else if (total_value_size % sizeof(byte8) == 0) {
         using VecV = byte8;
-        Launch_Pipeline_Upsert<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_Pipeline_Upsert<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                        stream);
       } else if (total_value_size % sizeof(byte4) == 0) {
         using VecV = byte4;
-        Launch_Pipeline_Upsert<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_Pipeline_Upsert<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                        stream);
       } else if (total_value_size % sizeof(byte2) == 0) {
         using VecV = byte2;
-        Launch_Pipeline_Upsert<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_Pipeline_Upsert<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                        stream);
       } else {
         using VecV = byte;
-        Launch_Pipeline_Upsert<K, V, S, VecV, Strategy>::launch_kernel(params,
+        Launch_Pipeline_Upsert<K, V, S, SS, VecV, Strategy>::launch_kernel(params,
                                                                        stream);
       }
     };
@@ -1229,9 +1225,10 @@ struct KernelSelector_Upsert {
   }  // End function
 };
 
-template <class K, class V, class S, int Strategy, uint32_t TILE_SIZE = 4>
+template <class K, class V, class S, class SS, int Strategy,
+          uint32_t TILE_SIZE = 4>
 __global__ void upsert_kernel_with_io_core(
-    const Table<K, V, S>* __restrict table, Bucket<K, V, S>* buckets,
+    const Table<K, V, S, SS>* __restrict table, Bucket<K, V, S, SS>* buckets,
     const size_t bucket_max_size, const size_t buckets_num, const size_t dim,
     const K* __restrict keys, const V* __restrict values,
     const S* __restrict scores, const S global_epoch, size_t N) {
@@ -1260,7 +1257,7 @@ __global__ void upsert_kernel_with_io_core(
     int src_lane = -1;
     K evicted_key;
 
-    Bucket<K, V, S>* bucket = get_key_position<K>(
+    Bucket<K, V, S, SS>* bucket = get_key_position<K>(
         buckets, insert_key, bkt_idx, start_idx, buckets_num, bucket_max_size);
 
     OccupyResult occupy_result{OccupyResult::INITIAL};
@@ -1304,21 +1301,21 @@ __global__ void upsert_kernel_with_io_core(
   }
 }
 
-template <typename K, typename V, typename S, int Strategy>
+template <typename K, typename V, typename S, class SS, int Strategy>
 struct SelectUpsertKernelWithIO {
   static void execute_kernel(const float& load_factor, const int& block_size,
                              const size_t bucket_max_size,
                              const size_t buckets_num, const size_t dim,
                              cudaStream_t& stream, const size_t& n,
-                             const Table<K, V, S>* __restrict table,
-                             Bucket<K, V, S>* buckets, const K* __restrict keys,
+                             const Table<K, V, S, SS>* __restrict table,
+                             Bucket<K, V, S, SS>* buckets, const K* __restrict keys,
                              const V* __restrict values,
                              const S* __restrict scores, const S global_epoch) {
     if (load_factor <= 0.5) {
       const unsigned int tile_size = 4;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      upsert_kernel_with_io_core<K, V, S, Strategy, tile_size>
+      upsert_kernel_with_io_core<K, V, S, SS, Strategy, tile_size>
           <<<grid_size, block_size, 0, stream>>>(
               table, buckets, bucket_max_size, buckets_num, dim, keys, values,
               scores, global_epoch, N);
@@ -1327,7 +1324,7 @@ struct SelectUpsertKernelWithIO {
       const unsigned int tile_size = 8;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      upsert_kernel_with_io_core<K, V, S, Strategy, tile_size>
+      upsert_kernel_with_io_core<K, V, S, SS, Strategy, tile_size>
           <<<grid_size, block_size, 0, stream>>>(
               table, buckets, bucket_max_size, buckets_num, dim, keys, values,
               scores, global_epoch, N);
@@ -1335,7 +1332,7 @@ struct SelectUpsertKernelWithIO {
       const unsigned int tile_size = 32;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      upsert_kernel_with_io_core<K, V, S, Strategy, tile_size>
+      upsert_kernel_with_io_core<K, V, S, SS, Strategy, tile_size>
           <<<grid_size, block_size, 0, stream>>>(
               table, buckets, bucket_max_size, buckets_num, dim, keys, values,
               scores, global_epoch, N);
@@ -1346,14 +1343,15 @@ struct SelectUpsertKernelWithIO {
 
 // Use 1 thread to deal with a KV-pair.
 template <typename K = uint64_t, typename V = byte4, typename S = uint64_t,
-          uint32_t BLOCK_SIZE = 128, int Strategy = -1>
+          class SS = AtomicScore<S>, uint32_t BLOCK_SIZE = 128,
+          int Strategy = -1>
 __global__ void upsert_kernel_lock_key_hybrid(
-    Bucket<K, V, S>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
+    Bucket<K, V, S, SS>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
     const uint64_t buckets_num, uint32_t bucket_capacity, const uint32_t dim,
     const K* __restrict__ keys, V** __restrict__ value_ptrs,
     const S* __restrict__ scores, K** __restrict__ key_ptrs,
     int* __restrict keys_index, uint64_t n, const S global_epoch) {
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using ScoreFunctor = ScoreFunctor<K, V, S, Strategy>;
 
   // bucket_capacity is a multiple of 4.
@@ -1535,10 +1533,7 @@ __global__ void upsert_kernel_lock_key_hybrid(
       if (result) {
         S* min_score_ptr =
             BUCKET::scores(bucket_keys_ptr, bucket_capacity, min_pos);
-        auto verify_score_ptr =
-            reinterpret_cast<AtomicScore<S>*>(min_score_ptr);
-        auto verify_score =
-            verify_score_ptr->load(cuda::std::memory_order_relaxed);
+        auto verify_score = *min_score_ptr;
         if (verify_score <= min_score) {
           key_pos = min_pos;
           ScoreFunctor::update_with_digest(bucket_keys_ptr, key_pos, scores,
@@ -1596,9 +1591,10 @@ __global__ void write_kernel_unlock_key(const V* __restrict src,
 
 /* Upsert with the end-user specified score.
  */
-template <class K, class V, class S, int Strategy, uint32_t TILE_SIZE = 4>
-__global__ void upsert_kernel(const Table<K, V, S>* __restrict table,
-                              Bucket<K, V, S>* buckets,
+template <class K, class V, class S, class SS, int Strategy,
+          uint32_t TILE_SIZE = 4>
+__global__ void upsert_kernel(const Table<K, V, S, SS>* __restrict table,
+                              Bucket<K, V, S, SS>* buckets,
                               const size_t bucket_max_size,
                               const size_t buckets_num, const size_t dim,
                               const K* __restrict keys, V** __restrict vectors,
@@ -1626,7 +1622,7 @@ __global__ void upsert_kernel(const Table<K, V, S>* __restrict table,
     int src_lane = -1;
     K evicted_key;
 
-    Bucket<K, V, S>* bucket = get_key_position<K>(
+    Bucket<K, V, S, SS>* bucket = get_key_position<K>(
         buckets, insert_key, bkt_idx, start_idx, buckets_num, bucket_max_size);
 
     if (src_offset != nullptr && g.thread_rank() == 0) {

--- a/include/merlin/core_kernels/upsert.cuh
+++ b/include/merlin/core_kernels/upsert.cuh
@@ -1264,12 +1264,12 @@ __global__ void upsert_kernel_with_io_core(
     const int bucket_size = buckets_size[bkt_idx];
     do {
       if (bucket_size < bucket_max_size) {
-        occupy_result = find_and_lock_when_vacant<K, V, S, TILE_SIZE>(
+        occupy_result = find_and_lock_when_vacant<K, V, S, SS, TILE_SIZE>(
             g, bucket, insert_key, insert_score, evicted_key, start_idx,
             key_pos, src_lane, bucket_max_size);
       } else {
         start_idx = (start_idx / TILE_SIZE) * TILE_SIZE;
-        occupy_result = find_and_lock_when_full<K, V, S, TILE_SIZE,
+        occupy_result = find_and_lock_when_full<K, V, S, SS, TILE_SIZE,
                                                 ScoreFunctor::LOCK_MEM_ORDER,
                                                 ScoreFunctor::UNLOCK_MEM_ORDER>(
             g, bucket, insert_key, insert_score, evicted_key, start_idx,
@@ -1633,12 +1633,12 @@ __global__ void upsert_kernel(const Table<K, V, S, SS>* __restrict table,
     const int bucket_size = buckets_size[bkt_idx];
     do {
       if (bucket_size < bucket_max_size) {
-        occupy_result = find_and_lock_when_vacant<K, V, S, TILE_SIZE>(
+        occupy_result = find_and_lock_when_vacant<K, V, S, SS, TILE_SIZE>(
             g, bucket, insert_key, insert_score, evicted_key, start_idx,
             key_pos, src_lane, bucket_max_size);
       } else {
         start_idx = (start_idx / TILE_SIZE) * TILE_SIZE;
-        occupy_result = find_and_lock_when_vacant<K, V, S, TILE_SIZE>(
+        occupy_result = find_and_lock_when_vacant<K, V, S, SS, TILE_SIZE>(
             g, bucket, insert_key, insert_score, evicted_key, start_idx,
             key_pos, src_lane, bucket_max_size);
       }

--- a/include/merlin/core_kernels/upsert_and_evict.cuh
+++ b/include/merlin/core_kernels/upsert_and_evict.cuh
@@ -23,15 +23,16 @@ namespace merlin {
 
 // Use 1 thread to deal with a KV-pair, including copying value.
 template <typename K = uint64_t, typename V = byte4, typename S = uint64_t,
-          typename VecV = byte16, uint32_t BLOCK_SIZE = 128, int Strategy = -1>
+          class SS = AtomicScore<S>, typename VecV = byte16,
+          uint32_t BLOCK_SIZE = 128, int Strategy = -1>
 __global__ void tlp_v1_upsert_and_evict_kernel_unique(
-    Bucket<K, V, S>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
+    Bucket<K, V, S, SS>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
     const uint64_t buckets_num, uint32_t bucket_capacity, const uint32_t dim,
     const K* __restrict__ keys, const VecV* __restrict__ values,
     const S* __restrict__ scores, K* __restrict__ evicted_keys,
     VecV* __restrict__ evicted_values, S* __restrict__ evicted_scores,
     uint64_t n, uint64_t* __restrict__ evicted_counter, const S global_epoch) {
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using CopyValue = CopyValueMultipleGroup<VecV, 1>;
   using ScoreFunctor = ScoreFunctor<K, V, S, Strategy>;
 
@@ -205,10 +206,7 @@ __global__ void tlp_v1_upsert_and_evict_kernel_unique(
       if (result) {
         S* min_score_ptr =
             BUCKET::scores(bucket_keys_ptr, bucket_capacity, min_pos);
-        auto verify_score_ptr =
-            reinterpret_cast<AtomicScore<S>*>(min_score_ptr);
-        auto verify_score =
-            verify_score_ptr->load(cuda::std::memory_order_relaxed);
+        auto verify_score = *min_score_ptr;
         if (verify_score <= min_score) {
           key_pos = min_pos;
           ScoreFunctor::update_with_digest(
@@ -249,16 +247,17 @@ __global__ void tlp_v1_upsert_and_evict_kernel_unique(
 
 // Use 1 thread to deal with a KV-pair, but use a threads group cto copy value.
 template <typename K = uint64_t, typename V = byte4, typename S = uint64_t,
-          typename VecV = byte16, uint32_t BLOCK_SIZE = 128,
-          uint32_t GROUP_SIZE = 16, int Strategy = -1>
+          class SS = AtomicScore<S>, typename VecV = byte16,
+          uint32_t BLOCK_SIZE = 128, uint32_t GROUP_SIZE = 16,
+          int Strategy = -1>
 __global__ void tlp_v2_upsert_and_evict_kernel_unique(
-    Bucket<K, V, S>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
+    Bucket<K, V, S, SS>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
     const uint64_t buckets_num, uint32_t bucket_capacity, const uint32_t dim,
     const K* __restrict__ keys, const VecV* __restrict__ values,
     const S* __restrict__ scores, K* __restrict__ evicted_keys,
     VecV* __restrict__ evicted_values, S* __restrict__ evicted_scores,
     uint64_t n, uint64_t* __restrict__ evicted_counter, const S global_epoch) {
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using CopyValue = CopyValueMultipleGroup<VecV, GROUP_SIZE>;
   using ScoreFunctor = ScoreFunctor<K, V, S, Strategy>;
 
@@ -440,10 +439,7 @@ __global__ void tlp_v2_upsert_and_evict_kernel_unique(
       if (result) {
         S* min_score_ptr =
             BUCKET::scores(bucket_keys_ptr, bucket_capacity, min_pos);
-        auto verify_score_ptr =
-            reinterpret_cast<AtomicScore<S>*>(min_score_ptr);
-        auto verify_score =
-            verify_score_ptr->load(cuda::std::memory_order_relaxed);
+        auto verify_score = *min_score_ptr;
         if (verify_score <= min_score) {
           key_pos = min_pos;
           ScoreFunctor::update_with_digest(bucket_keys_ptr, key_pos, scores,
@@ -599,9 +595,10 @@ struct SharedMemoryManager_Pipeline_UpsertAndEvict {
 };
 
 template <typename K = uint64_t, typename V = byte4, typename S = uint64_t,
-          typename VecV = byte16, uint32_t BLOCK_SIZE = 128, int Strategy = -1>
+          class SS = AtomicScore<S>, typename VecV = byte16,
+          uint32_t BLOCK_SIZE = 128, int Strategy = -1>
 __global__ void pipeline_upsert_and_evict_kernel_unique(
-    Bucket<K, V, S>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
+    Bucket<K, V, S, SS>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
     const uint64_t buckets_num, const uint32_t dim, const K* __restrict__ keys,
     const VecV* __restrict__ values, const S* __restrict__ scores,
     K* __restrict__ evicted_keys, VecV* __restrict__ evicted_values,
@@ -614,7 +611,7 @@ __global__ void pipeline_upsert_and_evict_kernel_unique(
   constexpr uint32_t Load_LEN = sizeof(VecD_Load) / sizeof(D);
   constexpr uint32_t Load_LEN_S = sizeof(byte16) / sizeof(S);
 
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using CopyValue = CopyValueMultipleGroup<VecV, GROUP_SIZE>;
   using SMM =
       SharedMemoryManager_Pipeline_UpsertAndEvict<K, V, S, VecV, BLOCK_SIZE,
@@ -854,10 +851,7 @@ __global__ void pipeline_upsert_and_evict_kernel_unique(
               if (result) {
                 S* score_ptr = BUCKET::scores(bucket_keys_ptr, BUCKET_SIZE,
                                               min_pos_global);
-                auto verify_score_ptr =
-                    reinterpret_cast<AtomicScore<S>*>(score_ptr);
-                auto verify_score =
-                    verify_score_ptr->load(cuda::std::memory_order_relaxed);
+                auto verify_score = *score_ptr;
                 if (verify_score <= min_score_global) {
                   if (expected_key == static_cast<K>(RECLAIM_KEY)) {
                     occupy_result = OccupyResult::OCCUPIED_RECLAIMED;
@@ -991,10 +985,7 @@ __global__ void pipeline_upsert_and_evict_kernel_unique(
           if (result) {
             S* score_ptr =
                 BUCKET::scores(bucket_keys_ptr, BUCKET_SIZE, min_pos_global);
-            auto verify_score_ptr =
-                reinterpret_cast<AtomicScore<S>*>(score_ptr);
-            auto verify_score =
-                verify_score_ptr->load(cuda::std::memory_order_relaxed);
+            auto verify_score = *score_ptr;
             if (verify_score <= min_score_global) {
               if (expected_key == static_cast<K>(RECLAIM_KEY)) {
                 atomicAdd(bucket_size_ptr, 1);
@@ -1099,10 +1090,11 @@ __global__ void pipeline_upsert_and_evict_kernel_unique(
   }
 }
 
-template <typename K = uint64_t, typename V = float, typename S = uint64_t>
+template <typename K = uint64_t, typename V = float, typename S = uint64_t,
+          class SS = AtomicScore<S>>
 struct Params_UpsertAndEvict {
   Params_UpsertAndEvict(
-      float load_factor_, Bucket<K, V, S>* __restrict__ buckets_,
+      float load_factor_, Bucket<K, V, S, SS>* __restrict__ buckets_,
       int* buckets_size_, size_t buckets_num_, uint32_t bucket_capacity_,
       uint32_t dim_, const K* __restrict__ keys_, const V* __restrict__ values_,
       const S* __restrict__ scores_, K* __restrict__ evicted_keys_,
@@ -1124,7 +1116,7 @@ struct Params_UpsertAndEvict {
         evicted_counter(evicted_counter_),
         global_epoch(global_epoch_) {}
   float load_factor;
-  Bucket<K, V, S>* __restrict__ buckets;
+  Bucket<K, V, S, SS>* __restrict__ buckets;
   int* buckets_size;
   size_t buckets_num;
   uint32_t bucket_capacity;
@@ -1142,16 +1134,17 @@ struct Params_UpsertAndEvict {
 
 // Use 1 thread to deal with a KV-pair, but use a threads group to copy value.
 template <typename K = uint64_t, typename V = byte4, typename S = uint64_t,
-          typename VecV = byte16, uint32_t BLOCK_SIZE = 128,
-          uint32_t GROUP_SIZE = 32, int Strategy = -1>
+          class SS = AtomicScore<S>, typename VecV = byte16,
+          uint32_t BLOCK_SIZE = 128, uint32_t GROUP_SIZE = 32,
+          int Strategy = -1>
 __global__ void insert_and_evict_kernel_with_filter(
-    Bucket<K, V, S>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
+    Bucket<K, V, S, SS>* __restrict__ buckets, int32_t* __restrict__ buckets_size,
     const uint64_t buckets_num, uint32_t bucket_capacity, const uint32_t dim,
     const K* __restrict__ keys, const VecV* __restrict__ values,
     const S* __restrict__ scores, K* __restrict__ evicted_keys,
     VecV* __restrict__ evicted_values, S* __restrict__ evicted_scores,
     uint64_t n, uint64_t* __restrict__ evicted_counter, const S global_epoch) {
-  using BUCKET = Bucket<K, V, S>;
+  using BUCKET = Bucket<K, V, S, SS>;
   using CopyValue = CopyValueMultipleGroup<VecV, GROUP_SIZE>;
   using ScoreFunctor = ScoreFunctor<K, V, S, Strategy>;
 
@@ -1333,10 +1326,7 @@ __global__ void insert_and_evict_kernel_with_filter(
       if (result) {
         S* min_score_ptr =
             BUCKET::scores(bucket_keys_ptr, bucket_capacity, min_pos);
-        auto verify_score_ptr =
-            reinterpret_cast<AtomicScore<S>*>(min_score_ptr);
-        auto verify_score =
-            verify_score_ptr->load(cuda::std::memory_order_relaxed);
+        auto verify_score = *min_score_ptr;
         if (verify_score <= min_score) {
           key_pos = min_pos;
           ScoreFunctor::update_with_digest(bucket_keys_ptr, key_pos, scores,
@@ -1395,15 +1385,16 @@ __global__ void insert_and_evict_kernel_with_filter(
   }
 }
 
-template <typename K, typename V, typename S, typename VecV, int Strategy>
+template <typename K, typename V, typename S, class SS, typename VecV,
+          int Strategy>
 struct LaunchInsertAndEvictKernel {
-  using Params = Params_UpsertAndEvict<K, V, S>;
+  using Params = Params_UpsertAndEvict<K, V, S, SS>;
   inline static void launch(Params& params, cudaStream_t& stream) {
     constexpr int BLOCK_SIZE = 128;
     params.dim = params.dim * sizeof(V) / sizeof(VecV);
     constexpr int GROUP_SIZE = 32;
-    insert_and_evict_kernel_with_filter<K, V, S, VecV, BLOCK_SIZE, GROUP_SIZE,
-                                        Strategy>
+    insert_and_evict_kernel_with_filter<K, V, S, SS, VecV, BLOCK_SIZE,
+                                        GROUP_SIZE, Strategy>
         <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
             params.buckets, params.buckets_size, params.buckets_num,
             params.bucket_capacity, params.dim, params.keys,
@@ -1414,35 +1405,37 @@ struct LaunchInsertAndEvictKernel {
   }
 };
 
-template <typename K, typename V, typename S, int Strategy>
+template <typename K, typename V, typename S, class SS, int Strategy>
 struct InsertAndEvictKernelLauncher {
-  using Params = Params_UpsertAndEvict<K, V, S>;
+  using Params = Params_UpsertAndEvict<K, V, S, SS>;
   static void launch_kernel(Params& params, cudaStream_t& stream) {
     const uint32_t total_value_size =
         static_cast<uint32_t>(params.dim * sizeof(V));
     if (total_value_size % sizeof(byte16) == 0) {
       using VecV = byte16;
-      LaunchInsertAndEvictKernel<K, V, S, VecV, Strategy>::launch(params,
+      LaunchInsertAndEvictKernel<K, V, S, SS, VecV, Strategy>::launch(params,
                                                                   stream);
     } else if (total_value_size % sizeof(byte8) == 0) {
       using VecV = byte8;
-      LaunchInsertAndEvictKernel<K, V, S, VecV, Strategy>::launch(params,
+      LaunchInsertAndEvictKernel<K, V, S, SS, VecV, Strategy>::launch(params,
                                                                   stream);
     } else {
       using VecV = V;
-      LaunchInsertAndEvictKernel<K, V, S, VecV, Strategy>::launch(params,
+      LaunchInsertAndEvictKernel<K, V, S, SS, VecV, Strategy>::launch(params,
                                                                   stream);
     }
   }  // End function
 };
 
-template <typename K, typename V, typename S, typename VecV, int Strategy>
+template <typename K, typename V, typename S, class SS, typename VecV,
+          int Strategy>
 struct Launch_TLPv1_UpsertAndEvict {
-  using Params = Params_UpsertAndEvict<K, V, S>;
+  using Params = Params_UpsertAndEvict<K, V, S, SS>;
   inline static void launch_kernel(Params& params, cudaStream_t& stream) {
     constexpr int BLOCK_SIZE = 128;
     params.dim = params.dim * sizeof(V) / sizeof(VecV);
-    tlp_v1_upsert_and_evict_kernel_unique<K, V, S, VecV, BLOCK_SIZE, Strategy>
+    tlp_v1_upsert_and_evict_kernel_unique<K, V, S, SS, VecV, BLOCK_SIZE,
+                                          Strategy>
         <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
             params.buckets, params.buckets_size, params.buckets_num,
             params.bucket_capacity, params.dim, params.keys,
@@ -1453,15 +1446,16 @@ struct Launch_TLPv1_UpsertAndEvict {
   }
 };
 
-template <typename K, typename V, typename S, typename VecV, int Strategy>
+template <typename K, typename V, typename S, class SS, typename VecV,
+          int Strategy>
 struct Launch_TLPv2_UpsertAndEvict {
-  using Params = Params_UpsertAndEvict<K, V, S>;
+  using Params = Params_UpsertAndEvict<K, V, S, SS>;
   inline static void launch_kernel(Params& params, cudaStream_t& stream) {
     constexpr int BLOCK_SIZE = 128;
     params.dim = params.dim * sizeof(V) / sizeof(VecV);
     if (params.dim <= 8) {
       constexpr int GROUP_SIZE = 8;
-      tlp_v2_upsert_and_evict_kernel_unique<K, V, S, VecV, BLOCK_SIZE,
+      tlp_v2_upsert_and_evict_kernel_unique<K, V, S, SS, VecV, BLOCK_SIZE,
                                             GROUP_SIZE, Strategy>
           <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
               params.buckets, params.buckets_size, params.buckets_num,
@@ -1473,7 +1467,7 @@ struct Launch_TLPv2_UpsertAndEvict {
               params.global_epoch);
     } else {
       constexpr int GROUP_SIZE = 16;
-      tlp_v2_upsert_and_evict_kernel_unique<K, V, S, VecV, BLOCK_SIZE,
+      tlp_v2_upsert_and_evict_kernel_unique<K, V, S, SS, VecV, BLOCK_SIZE,
                                             GROUP_SIZE, Strategy>
           <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
               params.buckets, params.buckets_size, params.buckets_num,
@@ -1487,9 +1481,10 @@ struct Launch_TLPv2_UpsertAndEvict {
   }
 };
 
-template <typename K, typename V, typename S, typename VecV, int Strategy>
+template <typename K, typename V, typename S, class SS, typename VecV,
+          int Strategy>
 struct Launch_Pipeline_UpsertAndEvict {
-  using Params = Params_UpsertAndEvict<K, V, S>;
+  using Params = Params_UpsertAndEvict<K, V, S, SS>;
   inline static void launch_kernel(Params& params, cudaStream_t& stream) {
     constexpr int BLOCK_SIZE = 128;
     constexpr uint32_t GROUP_SIZE = 32;
@@ -1502,7 +1497,8 @@ struct Launch_Pipeline_UpsertAndEvict {
     uint32_t shared_mem = SMM::total_size(params.dim);
     shared_mem =
         (shared_mem + sizeof(byte16) - 1) / sizeof(byte16) * sizeof(byte16);
-    pipeline_upsert_and_evict_kernel_unique<K, V, S, VecV, BLOCK_SIZE, Strategy>
+    pipeline_upsert_and_evict_kernel_unique<K, V, S, SS, VecV, BLOCK_SIZE,
+                                            Strategy>
         <<<(params.n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, shared_mem,
            stream>>>(params.buckets, params.buckets_size, params.buckets_num,
                      params.dim, params.keys,
@@ -1540,10 +1536,11 @@ struct ValueConfig_UpsertAndEvict<Sm70> {
   static constexpr uint32_t size_pipeline = 64 * sizeof(byte4);
 };
 
-template <typename K, typename V, typename S, int Strategy, typename ArchTag>
+template <typename K, typename V, typename S, class SS, int Strategy,
+          typename ArchTag>
 struct KernelSelector_UpsertAndEvict {
   using ValueConfig = ValueConfig_UpsertAndEvict<ArchTag>;
-  using Params = Params_UpsertAndEvict<K, V, S>;
+  using Params = Params_UpsertAndEvict<K, V, S, SS>;
 
   static bool callable(bool unique_key, uint32_t bucket_size, uint32_t dim) {
     constexpr uint32_t MinBucketCap = sizeof(VecD_Load) / sizeof(D);
@@ -1567,23 +1564,23 @@ struct KernelSelector_UpsertAndEvict {
     auto launch_TLPv1 = [&]() {
       if (total_value_size % sizeof(byte16) == 0) {
         using VecV = byte16;
-        Launch_TLPv1_UpsertAndEvict<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_TLPv1_UpsertAndEvict<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else if (total_value_size % sizeof(byte8) == 0) {
         using VecV = byte8;
-        Launch_TLPv1_UpsertAndEvict<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_TLPv1_UpsertAndEvict<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else if (total_value_size % sizeof(byte4) == 0) {
         using VecV = byte4;
-        Launch_TLPv1_UpsertAndEvict<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_TLPv1_UpsertAndEvict<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else if (total_value_size % sizeof(byte2) == 0) {
         using VecV = byte2;
-        Launch_TLPv1_UpsertAndEvict<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_TLPv1_UpsertAndEvict<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else {
         using VecV = byte;
-        Launch_TLPv1_UpsertAndEvict<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_TLPv1_UpsertAndEvict<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       }
     };
@@ -1592,23 +1589,23 @@ struct KernelSelector_UpsertAndEvict {
     auto launch_TLPv2 = [&]() {
       if (total_value_size % sizeof(byte16) == 0) {
         using VecV = byte16;
-        Launch_TLPv2_UpsertAndEvict<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_TLPv2_UpsertAndEvict<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else if (total_value_size % sizeof(byte8) == 0) {
         using VecV = byte8;
-        Launch_TLPv2_UpsertAndEvict<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_TLPv2_UpsertAndEvict<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else if (total_value_size % sizeof(byte4) == 0) {
         using VecV = byte4;
-        Launch_TLPv2_UpsertAndEvict<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_TLPv2_UpsertAndEvict<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else if (total_value_size % sizeof(byte2) == 0) {
         using VecV = byte2;
-        Launch_TLPv2_UpsertAndEvict<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_TLPv2_UpsertAndEvict<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else {
         using VecV = byte;
-        Launch_TLPv2_UpsertAndEvict<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_TLPv2_UpsertAndEvict<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       }
     };
@@ -1617,23 +1614,23 @@ struct KernelSelector_UpsertAndEvict {
     auto launch_Pipeline = [&]() {
       if (total_value_size % sizeof(byte16) == 0) {
         using VecV = byte16;
-        Launch_Pipeline_UpsertAndEvict<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_Pipeline_UpsertAndEvict<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else if (total_value_size % sizeof(byte8) == 0) {
         using VecV = byte8;
-        Launch_Pipeline_UpsertAndEvict<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_Pipeline_UpsertAndEvict<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else if (total_value_size % sizeof(byte4) == 0) {
         using VecV = byte4;
-        Launch_Pipeline_UpsertAndEvict<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_Pipeline_UpsertAndEvict<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else if (total_value_size % sizeof(byte2) == 0) {
         using VecV = byte2;
-        Launch_Pipeline_UpsertAndEvict<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_Pipeline_UpsertAndEvict<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       } else {
         using VecV = byte;
-        Launch_Pipeline_UpsertAndEvict<K, V, S, VecV, Strategy>::launch_kernel(
+        Launch_Pipeline_UpsertAndEvict<K, V, S, SS, VecV, Strategy>::launch_kernel(
             params, stream);
       }
     };
@@ -1673,9 +1670,10 @@ struct KernelSelector_UpsertAndEvict {
   }  // End function
 };
 
-template <class K, class V, class S, int Strategy, uint32_t TILE_SIZE = 4>
+template <class K, class V, class S, class SS, int Strategy,
+          uint32_t TILE_SIZE = 4>
 __global__ void upsert_and_evict_kernel_with_io_core(
-    const Table<K, V, S>* __restrict table, Bucket<K, V, S>* buckets,
+    const Table<K, V, S, SS>* __restrict table, Bucket<K, V, S, SS>* buckets,
     const size_t bucket_max_size, const size_t buckets_num, const size_t dim,
     const K* __restrict keys, const V* __restrict values,
     const S* __restrict scores, K* __restrict evicted_keys,
@@ -1704,7 +1702,7 @@ __global__ void upsert_and_evict_kernel_with_io_core(
     int src_lane = -1;
     K evicted_key;
 
-    Bucket<K, V, S>* bucket = get_key_position<K>(
+    Bucket<K, V, S, SS>* bucket = get_key_position<K>(
         buckets, insert_key, bkt_idx, start_idx, buckets_num, bucket_max_size);
 
     OccupyResult occupy_result{OccupyResult::INITIAL};
@@ -1764,13 +1762,13 @@ __global__ void upsert_and_evict_kernel_with_io_core(
   }
 }
 
-template <typename K, typename V, typename S, int Strategy>
+template <typename K, typename V, typename S, class SS, int Strategy>
 struct SelectUpsertAndEvictKernelWithIO {
   static void execute_kernel(
       const float& load_factor, const int& block_size,
       const size_t bucket_max_size, const size_t buckets_num, const size_t dim,
       cudaStream_t& stream, const size_t& n,
-      const Table<K, V, S>* __restrict table, Bucket<K, V, S>* buckets,
+      const Table<K, V, S, SS>* __restrict table, Bucket<K, V, S, SS>* buckets,
       const K* __restrict keys, const V* __restrict values,
       const S* __restrict scores, K* __restrict evicted_keys,
       V* __restrict evicted_values, S* __restrict evicted_scores,
@@ -1779,7 +1777,7 @@ struct SelectUpsertAndEvictKernelWithIO {
       const unsigned int tile_size = 4;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      upsert_and_evict_kernel_with_io_core<K, V, S, Strategy, tile_size>
+      upsert_and_evict_kernel_with_io_core<K, V, S, SS, Strategy, tile_size>
           <<<grid_size, block_size, 0, stream>>>(
               table, buckets, bucket_max_size, buckets_num, dim, keys, values,
               scores, evicted_keys, evicted_values, evicted_scores,
@@ -1790,7 +1788,7 @@ struct SelectUpsertAndEvictKernelWithIO {
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
 
-      upsert_and_evict_kernel_with_io_core<K, V, S, Strategy, tile_size>
+      upsert_and_evict_kernel_with_io_core<K, V, S, SS, Strategy, tile_size>
           <<<grid_size, block_size, 0, stream>>>(
               table, buckets, bucket_max_size, buckets_num, dim, keys, values,
               scores, evicted_keys, evicted_values, evicted_scores,
@@ -1800,7 +1798,7 @@ struct SelectUpsertAndEvictKernelWithIO {
       const unsigned int tile_size = 32;
       const size_t N = n * tile_size;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
-      upsert_and_evict_kernel_with_io_core<K, V, S, Strategy, tile_size>
+      upsert_and_evict_kernel_with_io_core<K, V, S, SS, Strategy, tile_size>
           <<<grid_size, block_size, 0, stream>>>(
               table, buckets, bucket_max_size, buckets_num, dim, keys, values,
               scores, evicted_keys, evicted_values, evicted_scores,

--- a/include/merlin/core_kernels/upsert_and_evict.cuh
+++ b/include/merlin/core_kernels/upsert_and_evict.cuh
@@ -1707,12 +1707,12 @@ __global__ void upsert_and_evict_kernel_with_io_core(
     const int bucket_size = buckets_size[bkt_idx];
     do {
       if (bucket_size < bucket_max_size) {
-        occupy_result = find_and_lock_when_vacant<K, V, S, TILE_SIZE>(
+        occupy_result = find_and_lock_when_vacant<K, V, S, SS, TILE_SIZE>(
             g, bucket, insert_key, insert_score, evicted_key, start_idx,
             key_pos, src_lane, bucket_max_size);
       } else {
         start_idx = (start_idx / TILE_SIZE) * TILE_SIZE;
-        occupy_result = find_and_lock_when_full<K, V, S, TILE_SIZE,
+        occupy_result = find_and_lock_when_full<K, V, S, SS, TILE_SIZE,
                                                 ScoreFunctor::LOCK_MEM_ORDER,
                                                 ScoreFunctor::UNLOCK_MEM_ORDER>(
             g, bucket, insert_key, insert_score, evicted_key, start_idx,

--- a/include/merlin/types.cuh
+++ b/include/merlin/types.cuh
@@ -117,11 +117,36 @@ using AtomicScore = cuda::atomic<S, cuda::thread_scope_device>;
 template <class T>
 using AtomicPos = cuda::atomic<T, cuda::thread_scope_device>;
 
-template <class K, class V, class S>
+/// @brief Helper to load a score value from either AtomicScore<S>* or S*.
+template <class S>
+__forceinline__ __device__ S score_load(AtomicScore<S>* ptr) {
+  return ptr->load(cuda::std::memory_order_relaxed);
+}
+
+template <class S>
+__forceinline__ __device__ S score_load(S* ptr) {
+  return *ptr;
+}
+
+/// @brief Helper to store a score value to either AtomicScore<S>* or S*.
+template <class S>
+__forceinline__ __device__ void score_store(AtomicScore<S>* ptr, S val) {
+  ptr->store(val, cuda::std::memory_order_relaxed);
+}
+
+template <class S>
+__forceinline__ __device__ void score_store(S* ptr, S val) {
+  *ptr = val;
+}
+
+/// @brief Bucket structure with a defaulted score-storage type parameter.
+///
+/// @tparam SS The score storage type. Defaults to AtomicScore<S> for backward
+///            compatibility. For kCustomized mode, SS can be plain S.
+template <class K, class V, class S, class SS = AtomicScore<S>>
 struct Bucket {
   AtomicKey<K>* keys_;
-  /// TODO: compute the pointer of scores and digests using bucket_max_size
-  AtomicScore<S>* scores_;
+  SS* scores_;
   /// @brief not visible to users
   D* digests_;
   V* vectors;  // Pinned memory or HBM
@@ -134,7 +159,7 @@ struct Bucket {
     return keys_ + index;
   }
 
-  __forceinline__ __device__ AtomicScore<S>* scores(int index) const {
+  __forceinline__ __device__ SS* scores(int index) const {
     return scores_ + index;
   }
 
@@ -192,9 +217,9 @@ class Lock {
 
 using Mutex = Lock<cuda::thread_scope_device>;
 
-template <class K, class V, class S>
+template <class K, class V, class S, class SS = AtomicScore<S>>
 struct Table {
-  Bucket<K, V, S>* buckets;
+  Bucket<K, V, S, SS>* buckets;
   Mutex* locks;                 // mutex for write buckets
   int* buckets_size;            // size of each buckets.
   V** slices;                   // Handles of the HBM/ HMEM slices.

--- a/include/merlin_hashtable.cuh
+++ b/include/merlin_hashtable.cuh
@@ -902,8 +902,15 @@ class HashTable : public HashTableBase<K, V, S> {
   using allocator_type = BaseAllocator;
 
  private:
-  using TableCore = nv::merlin::Table<key_type, value_type, score_type>;
+  using ScoreStore = typename std::conditional<
+      (Strategy == static_cast<int>(EvictStrategy::kCustomized)),
+      score_type, AtomicScore<score_type>>::type;
+  using TableCore =
+      nv::merlin::Table<key_type, value_type, score_type, ScoreStore>;
   static constexpr unsigned int TILE_SIZE = 4;
+  static constexpr bool is_customized_ =
+      (evict_strategy ==
+       static_cast<int>(EvictStrategy::kCustomized));
 
   using DeviceMemoryPool = MemoryPool<DeviceAllocator<char>>;
   using HostMemoryPool = MemoryPool<HostAllocator<char>>;
@@ -917,8 +924,17 @@ class HashTable : public HashTableBase<K, V, S> {
                    std::is_same<key_type, uint64_t>::value),
                   "The key_type must be int64_t or uint64_t.");
 
-    static_assert(std::is_same<score_type, uint64_t>::value,
-                  "The key_type must be uint64_t.");
+    // Built-in strategies require uint64_t scores (for epoch/timestamp
+    // encoding). kCustomized mode allows any trivially-copyable score type.
+    static_assert(
+        evict_strategy == EvictStrategy::kCustomized ||
+            std::is_same<score_type, uint64_t>::value,
+        "Built-in eviction strategies (kLru, kLfu, kEpochLru, kEpochLfu) "
+        "require score_type to be uint64_t. Use kCustomized for other types.");
+
+    static_assert(
+        std::is_trivially_copyable<score_type>::value,
+        "The score_type must be trivially copyable.");
   };
 
   /**
@@ -930,7 +946,8 @@ class HashTable : public HashTableBase<K, V, S> {
       CUDA_CHECK(cudaDeviceSynchronize());
 
       initialized_ = false;
-      destroy_table<key_type, value_type, score_type>(&table_, allocator_);
+      destroy_table<key_type, value_type, score_type, ScoreStore>(
+          &table_, allocator_);
       allocator_->free(MemoryType::Device, d_table_);
       dev_mem_pool_.reset();
       host_mem_pool_.reset();
@@ -1000,7 +1017,7 @@ class HashTable : public HashTableBase<K, V, S> {
     shared_mem_size_ = deviceProp.sharedMemPerBlock;
     sm_cnt_ = deviceProp.multiProcessorCount;
     max_threads_per_block_ = deviceProp.maxThreadsPerBlock;
-    create_table<key_type, value_type, score_type>(
+    create_table<key_type, value_type, score_type, ScoreStore>(
         &table_, allocator_, options_.dim, options_.init_capacity,
         options_.max_capacity, options_.max_hbm_for_vectors,
         options_.max_bucket_size, options_.num_of_buckets_per_alloc);
@@ -1108,7 +1125,7 @@ class HashTable : public HashTableBase<K, V, S> {
       }
 
       using Selector = KernelSelector_Upsert<key_type, value_type, score_type,
-                                             evict_strategy_, ArchTag>;
+                                             ScoreStore, evict_strategy_, ArchTag>;
       if (Selector::callable(unique_key,
                              static_cast<uint32_t>(options_.max_bucket_size),
                              static_cast<uint32_t>(options_.dim))) {
@@ -1121,7 +1138,7 @@ class HashTable : public HashTableBase<K, V, S> {
         Selector::select_kernel(kernelParams, stream);
       } else {
         using Selector = SelectUpsertKernelWithIO<key_type, value_type,
-                                                  score_type, evict_strategy_>;
+                                                  score_type, ScoreStore, evict_strategy_>;
         Selector::execute_kernel(
             load_factor, options_.block_size, options_.max_bucket_size,
             table_->buckets_num, options_.dim, stream, n, d_table_,
@@ -1158,7 +1175,7 @@ class HashTable : public HashTableBase<K, V, S> {
         constexpr uint32_t BLOCK_SIZE = 128;
 
         upsert_kernel_lock_key_hybrid<key_type, value_type, score_type,
-                                      BLOCK_SIZE, evict_strategy_>
+                                      ScoreStore, BLOCK_SIZE, evict_strategy_>
             <<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
                 table_->buckets, table_->buckets_size, table_->buckets_num,
                 options_.max_bucket_size, options_.dim, keys, d_dst, scores,
@@ -1169,7 +1186,7 @@ class HashTable : public HashTableBase<K, V, S> {
         const size_t N = n * TILE_SIZE;
         const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
 
-        upsert_kernel<key_type, value_type, score_type, evict_strategy_,
+        upsert_kernel<key_type, value_type, score_type, ScoreStore, evict_strategy_,
                       TILE_SIZE><<<grid_size, block_size, 0, stream>>>(
             d_table_, table_->buckets, options_.max_bucket_size,
             table_->buckets_num, options_.dim, keys, d_dst, scores,
@@ -1307,7 +1324,7 @@ class HashTable : public HashTableBase<K, V, S> {
 
     using Selector =
         KernelSelector_UpsertAndEvict<key_type, value_type, score_type,
-                                      evict_strategy, ArchTag>;
+                                      ScoreStore, evict_strategy, ArchTag>;
     if (Selector::callable(unique_key,
                            static_cast<uint32_t>(options_.max_bucket_size),
                            static_cast<uint32_t>(options_.dim))) {
@@ -1321,7 +1338,7 @@ class HashTable : public HashTableBase<K, V, S> {
     } else if (unique_key and options_.max_bucket_size % 16 == 0) {
       using KernelLauncher =
           InsertAndEvictKernelLauncher<key_type, value_type, score_type,
-                                       evict_strategy>;
+                                       ScoreStore, evict_strategy>;
       typename KernelLauncher::Params kernelParams(
           load_factor, table_->buckets, table_->buckets_size,
           table_->buckets_num, static_cast<uint32_t>(options_.max_bucket_size),
@@ -1355,7 +1372,7 @@ class HashTable : public HashTableBase<K, V, S> {
       CUDA_CHECK(memset64Async(tmp_evict_keys, EMPTY_KEY_CPU, n, stream));
       using Selector =
           SelectUpsertAndEvictKernelWithIO<key_type, value_type, score_type,
-                                           evict_strategy>;
+                                           ScoreStore, evict_strategy>;
       Selector::execute_kernel(
           load_factor, options_.block_size, options_.max_bucket_size,
           table_->buckets_num, options_.dim, stream, n, d_table_,
@@ -1525,7 +1542,7 @@ class HashTable : public HashTableBase<K, V, S> {
     if (is_fast_mode()) {
       using Selector =
           SelectAccumOrAssignKernelWithIO<key_type, value_type, score_type,
-                                          evict_strategy>;
+                                          ScoreStore, evict_strategy>;
       static thread_local int step_counter = 0;
       static thread_local float load_factor = 0.0;
 
@@ -1561,7 +1578,7 @@ class HashTable : public HashTableBase<K, V, S> {
         const size_t N = n * TILE_SIZE;
         const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
 
-        accum_or_assign_kernel<key_type, value_type, score_type, evict_strategy,
+        accum_or_assign_kernel<key_type, value_type, score_type, ScoreStore, evict_strategy,
                                TILE_SIZE><<<grid_size, block_size, 0, stream>>>(
             d_table_, options_.max_bucket_size, table_->buckets_num, dim(),
             keys, dst, scores, accum_or_assigns, src_offset, founds,
@@ -1636,7 +1653,7 @@ class HashTable : public HashTableBase<K, V, S> {
 
       using Selector =
           KernelSelector_FindOrInsert<key_type, value_type, score_type,
-                                      evict_strategy, ArchTag>;
+                                      ScoreStore, evict_strategy, ArchTag>;
       if (Selector::callable(unique_key,
                              static_cast<uint32_t>(options_.max_bucket_size),
                              static_cast<uint32_t>(options_.dim))) {
@@ -1650,7 +1667,7 @@ class HashTable : public HashTableBase<K, V, S> {
       } else {
         using Selector =
             SelectFindOrInsertKernelWithIO<key_type, value_type, score_type,
-                                           evict_strategy>;
+                                           ScoreStore, evict_strategy>;
         Selector::execute_kernel(
             load_factor, options_.block_size, options_.max_bucket_size,
             table_->buckets_num, options_.dim, stream, n, d_table_,
@@ -1687,7 +1704,7 @@ class HashTable : public HashTableBase<K, V, S> {
         constexpr uint32_t BLOCK_SIZE = 128;
 
         find_or_insert_kernel_lock_key_hybrid<key_type, value_type, score_type,
-                                              BLOCK_SIZE, evict_strategy>
+                                              ScoreStore, BLOCK_SIZE, evict_strategy>
             <<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
                 table_->buckets, table_->buckets_size, table_->buckets_num,
                 options_.max_bucket_size, options_.dim, keys,
@@ -1699,7 +1716,7 @@ class HashTable : public HashTableBase<K, V, S> {
         const size_t N = n * TILE_SIZE;
         const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
 
-        find_or_insert_kernel<key_type, value_type, score_type, evict_strategy,
+        find_or_insert_kernel<key_type, value_type, score_type, ScoreStore, evict_strategy,
                               TILE_SIZE><<<grid_size, block_size, 0, stream>>>(
             d_table_, table_->buckets, options_.max_bucket_size,
             table_->buckets_num, options_.dim, keys, d_table_value_addrs,
@@ -1818,7 +1835,7 @@ class HashTable : public HashTableBase<K, V, S> {
 
       constexpr uint32_t BLOCK_SIZE = 128U;
       find_or_insert_ptr_kernel_lock_key<key_type, value_type, score_type,
-                                         BLOCK_SIZE, evict_strategy>
+                                         ScoreStore, BLOCK_SIZE, evict_strategy>
           <<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
               table_->buckets, table_->buckets_size, table_->buckets_num,
               options_.max_bucket_size, options_.dim, keys, values, scores,
@@ -1836,7 +1853,7 @@ class HashTable : public HashTableBase<K, V, S> {
       CUDA_CHECK(cudaMemsetAsync(keys_ptr, 0, dev_ws_size, stream));
 
       find_or_insert_ptr_kernel_lock_key<key_type, value_type, score_type,
-                                         BLOCK_SIZE, evict_strategy>
+                                         ScoreStore, BLOCK_SIZE, evict_strategy>
           <<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
               table_->buckets, table_->buckets_size, table_->buckets_num,
               options_.max_bucket_size, options_.dim, keys, values, scores,
@@ -1847,7 +1864,7 @@ class HashTable : public HashTableBase<K, V, S> {
               keys, keys_ptr, n);
     } else {
       using Selector = SelectFindOrInsertPtrKernel<key_type, value_type,
-                                                   score_type, evict_strategy>;
+                                                   score_type, ScoreStore, evict_strategy>;
       static thread_local int step_counter = 0;
       static thread_local float load_factor = 0.0;
 
@@ -1899,7 +1916,7 @@ class HashTable : public HashTableBase<K, V, S> {
           "small.");
     }
     constexpr uint32_t BLOCK_SIZE = 128U;
-    lock_kernel_with_filter<key_type, value_type, score_type, evict_strategy>
+    lock_kernel_with_filter<key_type, value_type, score_type, ScoreStore, evict_strategy>
         <<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
             table_->buckets, table_->buckets_num, options_.max_bucket_size,
             options_.dim, keys, locked_key_ptrs, success, scores, global_epoch_,
@@ -1990,7 +2007,7 @@ class HashTable : public HashTableBase<K, V, S> {
         load_factor = fast_load_factor(0, stream, false);
       }
       using Selector = KernelSelector_Update<key_type, value_type, score_type,
-                                             evict_strategy, ArchTag>;
+                                             ScoreStore, evict_strategy, ArchTag>;
       if (Selector::callable(unique_key,
                              static_cast<uint32_t>(options_.max_bucket_size),
                              static_cast<uint32_t>(options_.dim))) {
@@ -2002,7 +2019,7 @@ class HashTable : public HashTableBase<K, V, S> {
         Selector::select_kernel(kernelParams, stream);
       } else {
         using Selector = SelectUpdateKernelWithIO<key_type, value_type,
-                                                  score_type, evict_strategy>;
+                                                  score_type, ScoreStore, evict_strategy>;
         Selector::execute_kernel(
             load_factor, options_.block_size, options_.max_bucket_size,
             table_->buckets_num, options_.dim, stream, n, d_table_,
@@ -2038,7 +2055,7 @@ class HashTable : public HashTableBase<K, V, S> {
         constexpr uint32_t BLOCK_SIZE = 128U;
 
         tlp_update_kernel_hybrid<key_type, value_type, score_type,
-                                 evict_strategy>
+                                 ScoreStore, evict_strategy>
             <<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
                 table_->buckets, table_->buckets_num, options_.max_bucket_size,
                 options_.dim, keys, d_dst, scores, keys_ptr, d_src_offset,
@@ -2049,7 +2066,7 @@ class HashTable : public HashTableBase<K, V, S> {
         const size_t N = n * TILE_SIZE;
         const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
 
-        update_kernel<key_type, value_type, score_type, evict_strategy,
+        update_kernel<key_type, value_type, score_type, ScoreStore, evict_strategy,
                       TILE_SIZE><<<grid_size, block_size, 0, stream>>>(
             d_table_, table_->buckets, options_.max_bucket_size,
             table_->buckets_num, options_.dim, keys, d_dst, scores,
@@ -2144,7 +2161,7 @@ class HashTable : public HashTableBase<K, V, S> {
         load_factor = fast_load_factor(0, stream, false);
       }
       using Selector = KernelSelector_UpdateScore<key_type, value_type,
-                                                  score_type, evict_strategy>;
+                                                  score_type, ScoreStore, evict_strategy>;
       if (Selector::callable(unique_key,
                              static_cast<uint32_t>(options_.max_bucket_size))) {
         typename Selector::Params kernelParams(
@@ -2154,7 +2171,7 @@ class HashTable : public HashTableBase<K, V, S> {
         Selector::select_kernel(kernelParams, stream);
       } else {
         using Selector = SelectUpdateScoreKernel<key_type, value_type,
-                                                 score_type, evict_strategy>;
+                                                 score_type, ScoreStore, evict_strategy>;
         Selector::execute_kernel(load_factor, options_.block_size,
                                  options_.max_bucket_size, table_->buckets_num,
                                  stream, n, d_table_, table_->buckets, keys,
@@ -2210,7 +2227,7 @@ class HashTable : public HashTableBase<K, V, S> {
         load_factor = fast_load_factor(0, stream, false);
       }
       using Selector = KernelSelector_UpdateValues<key_type, value_type,
-                                                   score_type, ArchTag>;
+                                                   score_type, ScoreStore, ArchTag>;
       if (Selector::callable(unique_key,
                              static_cast<uint32_t>(options_.max_bucket_size),
                              static_cast<uint32_t>(options_.dim))) {
@@ -2221,7 +2238,7 @@ class HashTable : public HashTableBase<K, V, S> {
         Selector::select_kernel(kernelParams, stream);
       } else {
         using Selector =
-            SelectUpdateValuesKernelWithIO<key_type, value_type, score_type>;
+            SelectUpdateValuesKernelWithIO<key_type, value_type, score_type, ScoreStore>;
         Selector::execute_kernel(load_factor, options_.block_size,
                                  options_.max_bucket_size, table_->buckets_num,
                                  options_.dim, stream, n, d_table_,
@@ -2256,7 +2273,7 @@ class HashTable : public HashTableBase<K, V, S> {
       if (filter_condition) {
         constexpr uint32_t BLOCK_SIZE = 128U;
 
-        tlp_update_values_kernel_hybrid<key_type, value_type, score_type>
+        tlp_update_values_kernel_hybrid<key_type, value_type, score_type, ScoreStore>
             <<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
                 table_->buckets, table_->buckets_num, options_.max_bucket_size,
                 options_.dim, keys, d_dst, keys_ptr, d_src_offset, n);
@@ -2266,7 +2283,7 @@ class HashTable : public HashTableBase<K, V, S> {
         const size_t N = n * TILE_SIZE;
         const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
 
-        update_values_kernel<key_type, value_type, score_type, TILE_SIZE>
+        update_values_kernel<key_type, value_type, score_type, ScoreStore, TILE_SIZE>
             <<<grid_size, block_size, 0, stream>>>(
                 d_table_, table_->buckets, options_.max_bucket_size,
                 table_->buckets_num, options_.dim, keys, d_dst, d_src_offset,
@@ -2370,17 +2387,17 @@ class HashTable : public HashTableBase<K, V, S> {
 
     if (is_fast_mode()) {
       using Selector = SelectPipelineLookupKernelWithIO<key_type, value_type,
-                                                        score_type, ArchTag>;
+                                                        score_type, ScoreStore, ArchTag>;
       const uint32_t pipeline_max_size = Selector::max_value_size();
       // Pipeline lookup kernel only supports "bucket_size = 128".
       if (options_.max_bucket_size == 128 && value_size <= pipeline_max_size) {
-        LookupKernelParams<key_type, value_type, score_type> lookupParams(
+        LookupKernelParams<key_type, value_type, score_type, ScoreStore> lookupParams(
             table_->buckets, table_->buckets_num, static_cast<uint32_t>(dim()),
             keys, values, scores, founds, n);
         Selector::select_kernel(lookupParams, stream);
       } else {
         using Selector =
-            SelectLookupKernelWithIO<key_type, value_type, score_type>;
+            SelectLookupKernelWithIO<key_type, value_type, score_type, ScoreStore>;
         static thread_local int step_counter = 0;
         static thread_local float load_factor = 0.0;
 
@@ -2419,7 +2436,7 @@ class HashTable : public HashTableBase<K, V, S> {
       if (filter_condition) {
         constexpr uint32_t BLOCK_SIZE = 128U;
 
-        tlp_lookup_kernel_hybrid<key_type, value_type, score_type>
+        tlp_lookup_kernel_hybrid<key_type, value_type, score_type, ScoreStore>
             <<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
                 table_->buckets, table_->buckets_num, options_.max_bucket_size,
                 options_.dim, keys, src, scores, dst_offset, founds, n);
@@ -2428,7 +2445,7 @@ class HashTable : public HashTableBase<K, V, S> {
         const size_t N = n * TILE_SIZE;
         const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
 
-        lookup_kernel<key_type, value_type, score_type, TILE_SIZE>
+        lookup_kernel<key_type, value_type, score_type, ScoreStore, TILE_SIZE>
             <<<grid_size, block_size, 0, stream>>>(
                 d_table_, table_->buckets, options_.max_bucket_size,
                 table_->buckets_num, options_.dim, keys, src, scores, founds,
@@ -2496,17 +2513,17 @@ class HashTable : public HashTableBase<K, V, S> {
 
     if (is_fast_mode()) {
       using Selector = SelectPipelineLookupKernelWithIO<key_type, value_type,
-                                                        score_type, ArchTag>;
+                                                        score_type, ScoreStore, ArchTag>;
       const uint32_t pipeline_max_size = Selector::max_value_size();
       // Pipeline lookup kernel only supports "bucket_size = 128".
       if (options_.max_bucket_size == 128 && value_size <= pipeline_max_size) {
-        LookupKernelParamsV2<key_type, value_type, score_type> lookupParams(
+        LookupKernelParamsV2<key_type, value_type, score_type, ScoreStore> lookupParams(
             table_->buckets, table_->buckets_num, static_cast<uint32_t>(dim()),
             keys, values, scores, missed_keys, missed_indices, missed_size, n);
         Selector::select_kernel(lookupParams, stream);
       } else {
         using Selector =
-            SelectLookupKernelWithIOV2<key_type, value_type, score_type>;
+            SelectLookupKernelWithIOV2<key_type, value_type, score_type, ScoreStore>;
         static thread_local int step_counter = 0;
         static thread_local float load_factor = 0.0;
 
@@ -2546,7 +2563,7 @@ class HashTable : public HashTableBase<K, V, S> {
       if (filter_condition) {
         constexpr uint32_t BLOCK_SIZE = 128U;
 
-        tlp_lookup_kernel_hybrid<key_type, value_type, score_type>
+        tlp_lookup_kernel_hybrid<key_type, value_type, score_type, ScoreStore>
             <<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
                 table_->buckets, table_->buckets_num, options_.max_bucket_size,
                 options_.dim, keys, src, scores, dst_offset, missed_keys,
@@ -2556,7 +2573,7 @@ class HashTable : public HashTableBase<K, V, S> {
         const size_t N = n * TILE_SIZE;
         const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
 
-        lookup_kernel<key_type, value_type, score_type, TILE_SIZE>
+        lookup_kernel<key_type, value_type, score_type, ScoreStore, TILE_SIZE>
             <<<grid_size, block_size, 0, stream>>>(
                 d_table_, table_->buckets, options_.max_bucket_size,
                 table_->buckets_num, options_.dim, keys, src, scores,
@@ -2621,13 +2638,13 @@ class HashTable : public HashTableBase<K, V, S> {
     if (unique_key && options_.max_bucket_size >= MinBucketCapacityFilter) {
       constexpr uint32_t BLOCK_SIZE = 128U;
       tlp_lookup_ptr_kernel_with_filter<key_type, value_type, score_type,
-                                        evict_strategy>
+                                        ScoreStore, evict_strategy>
           <<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
               table_->buckets, table_->buckets_num, options_.max_bucket_size,
               options_.dim, keys, values, scores, founds, n, false,
               global_epoch_);
     } else {
-      using Selector = SelectLookupPtrKernel<key_type, value_type, score_type>;
+      using Selector = SelectLookupPtrKernel<key_type, value_type, score_type, ScoreStore>;
       static thread_local int step_counter = 0;
       static thread_local float load_factor = 0.0;
 
@@ -2686,7 +2703,7 @@ class HashTable : public HashTableBase<K, V, S> {
     if (unique_key && options_.max_bucket_size >= MinBucketCapacityFilter) {
       constexpr uint32_t BLOCK_SIZE = 128U;
       tlp_lookup_ptr_kernel_with_filter<key_type, value_type, score_type,
-                                        evict_strategy>
+                                        ScoreStore, evict_strategy>
           <<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
               table_->buckets, table_->buckets_num, options_.max_bucket_size,
               options_.dim, keys, values, scores, founds, n, true,
@@ -2726,13 +2743,13 @@ class HashTable : public HashTableBase<K, V, S> {
     if (options_.max_bucket_size == 128) {
       // Pipeline lookup kernel only supports "bucket_size = 128".
       using Selector = SelectPipelineContainsKernel<key_type, value_type,
-                                                    score_type, ArchTag>;
-      ContainsKernelParams<key_type, value_type, score_type> containsParams(
+                                                    score_type, ScoreStore, ArchTag>;
+      ContainsKernelParams<key_type, value_type, score_type, ScoreStore> containsParams(
           table_->buckets, table_->buckets_num, static_cast<uint32_t>(dim()),
           keys, founds, n);
       Selector::select_kernel(containsParams, stream);
     } else {
-      using Selector = SelectContainsKernel<key_type, value_type, score_type>;
+      using Selector = SelectContainsKernel<key_type, value_type, score_type, ScoreStore>;
       static thread_local int step_counter = 0;
       static thread_local float load_factor = 0.0;
 
@@ -2770,7 +2787,7 @@ class HashTable : public HashTableBase<K, V, S> {
       const size_t N = n * TILE_SIZE;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
 
-      remove_kernel<key_type, value_type, score_type, TILE_SIZE>
+      remove_kernel<key_type, value_type, score_type, ScoreStore, TILE_SIZE>
           <<<grid_size, block_size, 0, stream>>>(
               d_table_, keys, table_->buckets, table_->buckets_size,
               table_->bucket_max_size, table_->buckets_num, N);
@@ -2829,7 +2846,7 @@ class HashTable : public HashTableBase<K, V, S> {
       const size_t N = table_->buckets_num;
       const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
 
-      remove_kernel<key_type, value_type, score_type, PredFunctor>
+      remove_kernel<key_type, value_type, score_type, ScoreStore, PredFunctor>
           <<<grid_size, block_size, 0, stream>>>(
               d_table_, pattern, threshold, d_count, table_->buckets,
               table_->buckets_size, table_->bucket_max_size,
@@ -2873,16 +2890,16 @@ class HashTable : public HashTableBase<K, V, S> {
       uint64_t n = options_.max_capacity;
       auto kernel = [&] {
         if (dim >= 32 && n % 32 == 0) {
-          return remove_kernel_v2<key_type, value_type, score_type, PredFunctor,
+          return remove_kernel_v2<key_type, value_type, score_type, ScoreStore, PredFunctor,
                                   32>;
         } else if (dim >= 16 && n % 16 == 0) {
-          return remove_kernel_v2<key_type, value_type, score_type, PredFunctor,
+          return remove_kernel_v2<key_type, value_type, score_type, ScoreStore, PredFunctor,
                                   16>;
         } else if (dim >= 8 && n % 8 == 0) {
-          return remove_kernel_v2<key_type, value_type, score_type, PredFunctor,
+          return remove_kernel_v2<key_type, value_type, score_type, ScoreStore, PredFunctor,
                                   8>;
         }
-        return remove_kernel_v2<key_type, value_type, score_type, PredFunctor,
+        return remove_kernel_v2<key_type, value_type, score_type, ScoreStore, PredFunctor,
                                 1>;
       }();
       uint64_t block_size = 128UL;
@@ -2917,7 +2934,7 @@ class HashTable : public HashTableBase<K, V, S> {
     const size_t N = table_->buckets_num * table_->bucket_max_size;
     const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
 
-    clear_kernel<key_type, value_type, score_type>
+    clear_kernel<key_type, value_type, score_type, ScoreStore>
         <<<grid_size, block_size, 0, stream>>>(d_table_, table_->buckets, N);
 
     CudaCheckError();
@@ -2971,7 +2988,7 @@ class HashTable : public HashTableBase<K, V, S> {
 
     const size_t grid_size = SAFE_GET_GRID_SIZE(n, block_size);
 
-    dump_kernel<key_type, value_type, score_type>
+    dump_kernel<key_type, value_type, score_type, ScoreStore>
         <<<grid_size, block_size, shared_size, stream>>>(
             d_table_, table_->buckets, keys, values, scores, offset, n,
             d_counter);
@@ -3074,17 +3091,17 @@ class HashTable : public HashTableBase<K, V, S> {
       using VecV = decltype(vec);
       size_t vec_dim = value_size / sizeof(VecV);
       if (vec_dim >= 32 && check_tile_size(32)) {
-        return dump_kernel_v2<key_type, value_type, score_type, VecV,
+        return dump_kernel_v2<key_type, value_type, score_type, ScoreStore, VecV,
                               PredFunctor, 32>;
       } else if (vec_dim >= 16 && check_tile_size(16)) {
-        return dump_kernel_v2<key_type, value_type, score_type, VecV,
+        return dump_kernel_v2<key_type, value_type, score_type, ScoreStore, VecV,
                               PredFunctor, 16>;
       } else if (vec_dim >= 8 && check_tile_size(8)) {
-        return dump_kernel_v2<key_type, value_type, score_type, VecV,
+        return dump_kernel_v2<key_type, value_type, score_type, ScoreStore, VecV,
                               PredFunctor, 8>;
       }
       match_fast_cond = false;
-      return dump_kernel<key_type, value_type, score_type, PredFunctor>;
+      return dump_kernel<key_type, value_type, score_type, ScoreStore, PredFunctor>;
     };
     auto kernel = [&] {
       if (value_size >= sizeof(float4) * 8 &&
@@ -3179,13 +3196,13 @@ class HashTable : public HashTableBase<K, V, S> {
     uint64_t dim = table_->dim;
     auto kernel = [&] {
       if (dim >= 32 && n % 32 == 0) {
-        return dump_kernel<key_type, value_type, score_type, PredFunctor, 32>;
+        return dump_kernel<key_type, value_type, score_type, ScoreStore, PredFunctor, 32>;
       } else if (dim >= 16 && n % 16 == 0) {
-        return dump_kernel<key_type, value_type, score_type, PredFunctor, 16>;
+        return dump_kernel<key_type, value_type, score_type, ScoreStore, PredFunctor, 16>;
       } else if (dim >= 8 && n % 8 == 0) {
-        return dump_kernel<key_type, value_type, score_type, PredFunctor, 8>;
+        return dump_kernel<key_type, value_type, score_type, ScoreStore, PredFunctor, 8>;
       }
-      return dump_kernel<key_type, value_type, score_type, PredFunctor, 1>;
+      return dump_kernel<key_type, value_type, score_type, ScoreStore, PredFunctor, 1>;
     }();
     uint64_t block_size = 128UL;
     uint64_t grid_size = std::min(sm_cnt_ * max_threads_per_block_ / block_size,
@@ -3236,16 +3253,16 @@ class HashTable : public HashTableBase<K, V, S> {
     uint64_t dim = table_->dim;
     auto kernel = [&] {
       if (dim >= 32 && n % 32 == 0) {
-        return traverse_kernel<key_type, value_type, score_type, ExecutionFunc,
+        return traverse_kernel<key_type, value_type, score_type, ScoreStore, ExecutionFunc,
                                32>;
       } else if (dim >= 16 && n % 16 == 0) {
-        return traverse_kernel<key_type, value_type, score_type, ExecutionFunc,
+        return traverse_kernel<key_type, value_type, score_type, ScoreStore, ExecutionFunc,
                                16>;
       } else if (dim >= 8 && n % 8 == 0) {
-        return traverse_kernel<key_type, value_type, score_type, ExecutionFunc,
+        return traverse_kernel<key_type, value_type, score_type, ScoreStore, ExecutionFunc,
                                8>;
       }
-      return traverse_kernel<key_type, value_type, score_type, ExecutionFunc,
+      return traverse_kernel<key_type, value_type, score_type, ScoreStore, ExecutionFunc,
                              1>;
     }();
     uint64_t block_size = 128UL;
@@ -3320,7 +3337,7 @@ class HashTable : public HashTableBase<K, V, S> {
     grid_size = std::min(grid_size,
                          static_cast<size_t>(sm_cnt_ * max_threads_per_block_ /
                                              options_.block_size));
-    size_if_kernel<key_type, value_type, score_type, PredFunctor>
+    size_if_kernel<key_type, value_type, score_type, ScoreStore, PredFunctor>
         <<<grid_size, options_.block_size, 0, stream>>>(
             d_table_, table_->buckets, pattern, threshold, d_counter);
     CudaCheckError();
@@ -3369,7 +3386,8 @@ class HashTable : public HashTableBase<K, V, S> {
 
       while (capacity() < new_capacity &&
              capacity() * 2 <= options_.max_capacity) {
-        double_capacity<key_type, value_type, score_type>(&table_, allocator_);
+        double_capacity<key_type, value_type, score_type, ScoreStore>(
+            &table_, allocator_);
         CUDA_CHECK(cudaDeviceSynchronize());
         sync_table_configuration();
 
@@ -3377,7 +3395,8 @@ class HashTable : public HashTableBase<K, V, S> {
         const size_t N = TILE_SIZE * table_->buckets_num / 2;
         const size_t grid_size = SAFE_GET_GRID_SIZE(N, block_size);
 
-        rehash_kernel_for_fast_mode<key_type, value_type, score_type, TILE_SIZE>
+        rehash_kernel_for_fast_mode<key_type, value_type, score_type,
+                                    ScoreStore, TILE_SIZE>
             <<<grid_size, block_size, 0, stream>>>(d_table_, table_->buckets,
                                                    N);
       }
@@ -3503,7 +3522,7 @@ class HashTable : public HashTableBase<K, V, S> {
       // Dump the next batch to workspace, and then write it to the file.
       CUDA_CHECK(cudaMemsetAsync(d_count, 0, sizeof(size_type), stream));
 
-      dump_kernel<key_type, value_type, score_type>
+      dump_kernel<key_type, value_type, score_type, ScoreStore>
           <<<grid_size, block_size, shared_size, stream>>>(
               d_table_, table_->buckets, d_keys, d_values, d_scores, i,
               std::min(total_size - i, n), d_count);

--- a/include/merlin_hashtable.cuh
+++ b/include/merlin_hashtable.cuh
@@ -2743,6 +2743,10 @@ class HashTable : public HashTableBase<K, V, S> {
             bool* founds,                             // (n)
             score_type* scores = nullptr,             // (n)
             cudaStream_t stream = 0, bool unique_key = true) const {
+    MERLIN_CHECK(
+        !is_memory_mode(),
+        "[MEMORY_MODE] pointer-return find() is not supported in "
+        "dual-bucket mode. Key may reside in either bucket.");
     if (n == 0) {
       return;
     }
@@ -2827,6 +2831,10 @@ class HashTable : public HashTableBase<K, V, S> {
                        bool* founds,                             // (n)
                        score_type* scores = nullptr,             // (n)
                        cudaStream_t stream = 0, bool unique_key = true) {
+    MERLIN_CHECK(
+        !is_memory_mode(),
+        "[MEMORY_MODE] pointer-return find_and_update() is not supported "
+        "in dual-bucket mode. Key may reside in either bucket.");
     if (n == 0) {
       return;
     }

--- a/tests/dual_bucket_test.cc.cu
+++ b/tests/dual_bucket_test.cc.cu
@@ -501,6 +501,53 @@ TEST(DualBucketTest, ContainsGuard) {
   CUDA_CHECK(cudaFree(d_founds));
 }
 
+TEST(DualBucketTest, PointerFindGuard) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+  Table table;
+  create_memory_mode_table(table, 128 * 128);
+
+  K* d_keys;
+  V** d_values;
+  bool* d_founds;
+  S* d_scores;
+  CUDA_CHECK(cudaMalloc(&d_keys, sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, sizeof(V*)));
+  CUDA_CHECK(cudaMalloc(&d_founds, sizeof(bool)));
+  CUDA_CHECK(cudaMalloc(&d_scores, sizeof(S)));
+
+  EXPECT_THROW(table.find(1, d_keys, d_values, d_founds, d_scores, 0, true),
+               std::runtime_error);
+
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+  CUDA_CHECK(cudaFree(d_founds));
+  CUDA_CHECK(cudaFree(d_scores));
+}
+
+TEST(DualBucketTest, PointerFindAndUpdateGuard) {
+  using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
+  Table table;
+  create_memory_mode_table(table, 128 * 128);
+
+  K* d_keys;
+  V** d_values;
+  bool* d_founds;
+  S* d_scores;
+  CUDA_CHECK(cudaMalloc(&d_keys, sizeof(K)));
+  CUDA_CHECK(cudaMalloc(&d_values, sizeof(V*)));
+  CUDA_CHECK(cudaMalloc(&d_founds, sizeof(bool)));
+  CUDA_CHECK(cudaMalloc(&d_scores, sizeof(S)));
+
+  EXPECT_THROW(
+      table.find_and_update(1, d_keys, d_values, d_founds, d_scores, 0, true),
+      std::runtime_error);
+
+  CUDA_CHECK(cudaFree(d_keys));
+  CUDA_CHECK(cudaFree(d_values));
+  CUDA_CHECK(cudaFree(d_founds));
+  CUDA_CHECK(cudaFree(d_scores));
+}
+
 TEST(DualBucketTest, ReserveGuard) {
   using Table = nv::merlin::HashTable<K, V, S, EvictStrategy::kCustomized>;
   Table table;


### PR DESCRIPTION
To resolve: https://github.com/NVIDIA-Merlin/HierarchicalKV/issues/247 

Remove the `AtomicScore<S>` wrapper from score storage in `kCustomized` mode, allowing `S` to be any trivially-copyable user-defined type (not limited to `cuda::atomic`-compatible types like `uint64_t`). Built-in strategies (`kLru`, `kLfu`, `kEpochLru`, `kEpochLfu`) continue to use `AtomicScore<S>` unchanged.

## Key Changes

- Add defaulted `SS` (Score Storage) template parameter to `Bucket` and `Table`
- Add `score_load` / `score_store` helpers using function overloading
- Introduce `ScoreStore` alias via `std::conditional`, selecting `SS = S` for `kCustomized`
- Propagate `SS` to all ~80 kernel call sites across 15 files
- Replace `reinterpret_cast<AtomicScore<S>*>` verification patterns with plain dereference in eviction scan code
- Relax `static_assert` to allow any `trivially_copyable` `S` for `kCustomized`

## Backward Compatibility

Existing code such as:

```cpp
HashTable<K, V, uint64_t, kLru>
HashTable<K, V, uint64_t, kCustomized>