### PR TITLE
[Feat] Add pipelined pointer-return kernel for find* at high load factor

### DIFF
--- a/include/merlin/core_kernels/lookup_ptr.cuh
+++ b/include/merlin/core_kernels/lookup_ptr.cuh
@@ -151,6 +151,228 @@ WRITE_BACK:
   }
 }
 
+// Pipelined pointer-return lookup: reuses the cooperative 32-thread digest scan
+// from lookup_kernel_with_io_pipeline_v1 (the value-copy find kernel) but skips
+// the value copy stages entirely, writing only V* pointers.  This ensures find*
+// throughput at lambda=1.0 is always >= find throughput.
+template <typename K, typename V, typename S>
+__global__ void lookup_ptr_kernel_with_pipeline(
+    Bucket<K, V, S>* buckets, const size_t buckets_num, const int dim,
+    const K* __restrict keys, V** __restrict values, S* __restrict scores,
+    bool* __restrict founds, size_t n) {
+  constexpr int GROUP_SIZE = 32;
+  constexpr int RESERVE = 16;
+  constexpr int BLOCK_SIZE = 128;
+  constexpr int BUCKET_SIZE = 128;
+  constexpr int GROUP_NUM = BLOCK_SIZE / GROUP_SIZE;
+  constexpr int DIGEST_SPAN = BUCKET_SIZE / 4;
+
+  __shared__ int sm_target_digests[BLOCK_SIZE];
+  __shared__ K sm_target_keys[BLOCK_SIZE];
+  __shared__ K* sm_keys_ptr[BLOCK_SIZE];
+  __shared__ V* sm_values_ptr[BLOCK_SIZE];
+  // Reuse
+  int* sm_counts = sm_target_digests;
+  int* sm_founds = sm_counts;
+  // Double buffer
+  __shared__ uint32_t sm_probing_digests[2][GROUP_NUM * DIGEST_SPAN];
+  __shared__ K sm_possible_keys[2][GROUP_NUM * RESERVE];
+  __shared__ int sm_possible_pos[2][GROUP_NUM * RESERVE];
+
+  // Initialization
+  auto g = cg::tiled_partition<GROUP_SIZE>(cg::this_thread_block());
+  int groupID = threadIdx.x / GROUP_SIZE;
+  int rank = g.thread_rank();
+  int key_idx_base = (blockIdx.x * blockDim.x) + groupID * GROUP_SIZE;
+  if (key_idx_base >= n) return;
+  int loop_num =
+      (n - key_idx_base) < GROUP_SIZE ? (n - key_idx_base) : GROUP_SIZE;
+  if (rank < loop_num) {
+    int idx_block = groupID * GROUP_SIZE + rank;
+    K target_key = keys[key_idx_base + rank];
+    sm_target_keys[idx_block] = target_key;
+    const K hashed_key = Murmur3HashDevice(target_key);
+    const uint8_t target_digest = static_cast<uint8_t>(hashed_key >> 32);
+    sm_target_digests[idx_block] = static_cast<uint32_t>(target_digest);
+    int global_idx = hashed_key % (buckets_num * BUCKET_SIZE);
+    int bkt_idx = global_idx / BUCKET_SIZE;
+    Bucket<K, V, S>* bucket = buckets + bkt_idx;
+    __pipeline_memcpy_async(sm_keys_ptr + idx_block, bucket->keys_addr(),
+                            sizeof(K*));
+    __pipeline_commit();
+    __pipeline_memcpy_async(sm_values_ptr + idx_block, &(bucket->vectors),
+                            sizeof(V*));
+  }
+  __pipeline_wait_prior(0);
+
+  // Pipeline loading: prefetch digests for the first key
+  uint8_t* digests_ptr =
+      reinterpret_cast<uint8_t*>(sm_keys_ptr[groupID * GROUP_SIZE]) -
+      BUCKET_SIZE;
+  __pipeline_memcpy_async(sm_probing_digests[0] + groupID * DIGEST_SPAN + rank,
+                          digests_ptr + rank * 4, sizeof(uint32_t));
+  __pipeline_commit();
+  __pipeline_commit();
+
+  for (int i = 0; i < loop_num; i++) {
+    int key_idx_block = groupID * GROUP_SIZE + i;
+
+    /* Step1: prefetch all digests in one bucket */
+    if ((i + 1) < loop_num) {
+      uint8_t* digests_ptr =
+          reinterpret_cast<uint8_t*>(sm_keys_ptr[key_idx_block + 1]) -
+          BUCKET_SIZE;
+      __pipeline_memcpy_async(
+          sm_probing_digests[diff_buf(i)] + groupID * DIGEST_SPAN + rank,
+          digests_ptr + rank * 4, sizeof(uint32_t));
+    }
+    __pipeline_commit();
+
+    /* Step2: check digests and load possible keys */
+    uint32_t target_digest = sm_target_digests[key_idx_block];
+    uint32_t target_digests = __byte_perm(target_digest, target_digest, 0x0000);
+    sm_counts[key_idx_block] = 0;
+    __pipeline_wait_prior(2);
+    uint32_t probing_digests =
+        sm_probing_digests[same_buf(i)][groupID * DIGEST_SPAN + rank];
+    uint32_t find_result_ = __vcmpeq4(probing_digests, target_digests);
+    uint32_t find_result = 0;
+    if ((find_result_ & 0x01) != 0) find_result |= 0x01;
+    if ((find_result_ & 0x0100) != 0) find_result |= 0x02;
+    if ((find_result_ & 0x010000) != 0) find_result |= 0x04;
+    if ((find_result_ & 0x01000000) != 0) find_result |= 0x08;
+    int find_number = __popc(find_result);
+    int group_base = 0;
+    if (find_number > 0) {
+      group_base = atomicAdd(sm_counts + key_idx_block, find_number);
+    }
+    bool gt_reserve = (group_base + find_number) > RESERVE;
+    int gt_vote = g.ballot(gt_reserve);
+    K* key_ptr = sm_keys_ptr[key_idx_block];
+    if (gt_vote == 0) {
+      do {
+        int digest_idx = __ffs(find_result) - 1;
+        if (digest_idx >= 0) {
+          find_result &= (find_result - 1);
+          int key_pos = rank * 4 + digest_idx;
+          sm_possible_pos[same_buf(i)][groupID * RESERVE + group_base] =
+              key_pos;
+          __pipeline_memcpy_async(
+              sm_possible_keys[same_buf(i)] + (groupID * RESERVE + group_base),
+              key_ptr + key_pos, sizeof(K));
+          group_base += 1;
+        } else {
+          break;
+        }
+      } while (true);
+    } else {
+      K target_key = sm_target_keys[key_idx_block];
+      sm_counts[key_idx_block] = 0;
+      int found_vote = 0;
+      bool found = false;
+      do {
+        int digest_idx = __ffs(find_result) - 1;
+        if (digest_idx >= 0) {
+          find_result &= (find_result - 1);
+          int key_pos = rank * 4 + digest_idx;
+          K possible_key = key_ptr[key_pos];
+          if (possible_key == target_key) {
+            found = true;
+            sm_counts[key_idx_block] = 1;
+            sm_possible_pos[same_buf(i)][groupID * RESERVE] = key_pos;
+            sm_possible_keys[same_buf(i)][groupID * RESERVE] = possible_key;
+          }
+        }
+        found_vote = g.ballot(found);
+        if (found_vote) {
+          break;
+        }
+        found_vote = digest_idx >= 0;
+      } while (g.any(found_vote));
+    }
+    __pipeline_commit();
+
+    /* Step3: check possible keys, write back pointer immediately */
+    if (i > 0) {
+      int prev_idx_block = key_idx_block - 1;
+      K target_key = sm_target_keys[prev_idx_block];
+      int possible_num = sm_counts[prev_idx_block];
+      sm_founds[prev_idx_block] = 0;
+      __pipeline_wait_prior(2);
+      int key_pos = -1;
+      bool found_flag = false;
+      if (rank < possible_num) {
+        K possible_key =
+            sm_possible_keys[diff_buf(i)][groupID * RESERVE + rank];
+        key_pos = sm_possible_pos[diff_buf(i)][groupID * RESERVE + rank];
+        if (possible_key == target_key) {
+          found_flag = true;
+        }
+      }
+      int found_vote = g.ballot(found_flag);
+      if (found_vote) {
+        sm_founds[prev_idx_block] = 1;
+        int src_lane = __ffs(found_vote) - 1;
+        int target_pos = g.shfl(key_pos, src_lane);
+        // Write pointer directly (no value copy needed).
+        if (rank == 0) {
+          int key_idx_grid = blockIdx.x * blockDim.x + prev_idx_block;
+          values[key_idx_grid] =
+              sm_values_ptr[prev_idx_block] + target_pos * dim;
+          if (scores) {
+            S* score_ptr =
+                reinterpret_cast<S*>(sm_keys_ptr[prev_idx_block] + BUCKET_SIZE);
+            scores[key_idx_grid] = score_ptr[target_pos];
+          }
+        }
+      }
+    }
+  }  // End loop
+
+  /* Pipeline emptying: process the last key */
+  {
+    int key_idx_block = groupID * GROUP_SIZE + (loop_num - 1);
+    K target_key = sm_target_keys[key_idx_block];
+    int possible_num = sm_counts[key_idx_block];
+    sm_founds[key_idx_block] = 0;
+    __pipeline_wait_prior(0);
+    int key_pos = -1;
+    bool found_flag = false;
+    if (rank < possible_num) {
+      key_pos = sm_possible_pos[diff_buf(loop_num)][groupID * RESERVE + rank];
+      K possible_key =
+          sm_possible_keys[diff_buf(loop_num)][groupID * RESERVE + rank];
+      if (target_key == possible_key) {
+        found_flag = true;
+      }
+    }
+    int found_vote = g.ballot(found_flag);
+    if (found_vote) {
+      sm_founds[key_idx_block] = 1;
+      int src_lane = __ffs(found_vote) - 1;
+      int target_pos = g.shfl(key_pos, src_lane);
+      if (rank == 0) {
+        int key_idx_grid = blockIdx.x * blockDim.x + key_idx_block;
+        values[key_idx_grid] = sm_values_ptr[key_idx_block] + target_pos * dim;
+        if (scores) {
+          S* score_ptr =
+              reinterpret_cast<S*>(sm_keys_ptr[key_idx_block] + BUCKET_SIZE);
+          scores[key_idx_grid] = score_ptr[target_pos];
+        }
+      }
+    }
+  }
+
+  // Write found flags and nullptr for misses.
+  if (rank < loop_num) {
+    int key_idx_block = groupID * GROUP_SIZE + rank;
+    int key_idx_grid = blockIdx.x * blockDim.x + key_idx_block;
+    bool found_ = sm_founds[key_idx_block] > 0;
+    if (founds) founds[key_idx_grid] = found_;
+    if (!found_) values[key_idx_grid] = nullptr;
+  }
+}
+
 /* lookup with IO operation. This kernel is
  * usually used for the pure HBM mode for better performance.
  */

--- a/include/merlin_hashtable.cuh
+++ b/include/merlin_hashtable.cuh
@@ -2619,13 +2619,32 @@ class HashTable : public HashTableBase<K, V, S> {
 
     constexpr uint32_t MinBucketCapacityFilter = sizeof(VecD_Load) / sizeof(D);
     if (unique_key && options_.max_bucket_size >= MinBucketCapacityFilter) {
-      constexpr uint32_t BLOCK_SIZE = 128U;
-      tlp_lookup_ptr_kernel_with_filter<key_type, value_type, score_type,
-                                        evict_strategy>
-          <<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
-              table_->buckets, table_->buckets_num, options_.max_bucket_size,
-              options_.dim, keys, values, scores, founds, n, false,
-              global_epoch_);
+      // Track load factor to choose between TLP and pipelined kernels.
+      static thread_local int step_counter = 0;
+      static thread_local float load_factor = 0.0;
+      if (((step_counter++) % kernel_select_interval_) == 0) {
+        load_factor = fast_load_factor(0, stream, false);
+      }
+
+      if (load_factor > 0.875f && options_.max_bucket_size == 128) {
+        // At high load factors, the TLP kernel degrades because empty-slot
+        // early termination fails.  Switch to the pipelined cooperative kernel
+        // which scans all 128 digests in one parallel step (32 threads/key).
+        constexpr uint32_t BLOCK_SIZE = 128U;
+        const size_t grid_size = (n + BLOCK_SIZE - 1) / BLOCK_SIZE;
+        lookup_ptr_kernel_with_pipeline<key_type, value_type, score_type>
+            <<<grid_size, BLOCK_SIZE, 0, stream>>>(
+                table_->buckets, table_->buckets_num, options_.dim, keys,
+                values, scores, founds, n);
+      } else {
+        constexpr uint32_t BLOCK_SIZE = 128U;
+        tlp_lookup_ptr_kernel_with_filter<key_type, value_type, score_type,
+                                          evict_strategy>
+            <<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
+                table_->buckets, table_->buckets_num, options_.max_bucket_size,
+                options_.dim, keys, values, scores, founds, n, false,
+                global_epoch_);
+      }
     } else {
       using Selector = SelectLookupPtrKernel<key_type, value_type, score_type>;
       static thread_local int step_counter = 0;


### PR DESCRIPTION
## Problem

`find*` (pointer-return find) shows a ~61% throughput cliff at λ=1.0, dropping from ~7.0 to ~2.7 B-KV/s, while value-copy `find` stays stable at ~3.9 B-KV/s. This is logically wrong — `find*` does strictly less work than `find`, so it should never be slower.

**Root cause:** `find*` dispatches to `tlp_lookup_ptr_kernel_with_filter`, a 1-thread-per-key kernel that scans bucket digests serially in 9 iterations of 16 digests each, relying on empty-slot early termination. At λ=1.0, all 128 slots are occupied, so every miss scans all 9 iterations instead of ~2.

## Solution

Add `lookup_ptr_kernel_with_pipeline` — a stripped-down version of the value-copy `lookup_kernel_with_io_pipeline_v1` that returns `V*` pointers instead of copying values.

- **Thread model:** 32 threads per key (cooperative group), 4 keys/block
- **Pipeline:** 3-stage double-buffered (vs 4-stage in value-copy):
  1. Digest prefetch (all 128 digests in 1 parallel step)
  2. Digest match + key prefetch
  3. Key verify + write pointer (no value copy)
- **Dispatch:** `load_factor > 0.875 && max_bucket_size == 128` selects the pipelined kernel; otherwise the fast TLP kernel is used as before.

## Benchmark (H100 NVL, pure HBM, dim=8, capacity=128M)

| λ    | find* before | find* after | find (ref) | Δ     |
|------|-------------|------------|-----------|-------|
| 0.50 | 6.977       | 6.942      | 3.910     | -0.5% |
| 0.75 | 5.954       | 5.963      | 3.881     | +0.2% |
| 1.00 | 2.688       | **4.366**  | 3.929     | **+62%** |

`find*` at λ=1.0 is now 11% faster than `find` (was 32% slower). No regression at low load factors.